### PR TITLE
Update Alternate Rarity Color script

### DIFF
--- a/data/magic-m15-adventure.mse-style/style
+++ b/data/magic-m15-adventure.mse-style/style
@@ -6,7 +6,7 @@ icon: card-sample.png
 installer group: magic/m15 style/split cards
 position hint: 011
 
-version: 2023-02-13
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -113,44 +113,184 @@ init script:
 	card_shape := {"adventure"}
 	
 	# alternate rarity color
-	alt_rarity := {styling.alt_rarity_color != ""}
-	alt_rarity_color := {
-		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
-		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
-		colons := length(filter_text(string, match:":"))
-		output := split_text(string, match:",|:")
-		splits := split_text(string, match:":")
-		final_num := to_real(splits[length(splits)-2]) or else 0
-		final_border := final_num > 0 and final_num < 1
-		final_num := if not final_border then "0.07" else to_string(final_num);
-		if final_border then (
-			colons := colons - 1;
-			string := replace(string, match:"{final_num}:", replace:"")
-		)
-		if colons == 4
-			then output := split_text(string+final_num+":", match:",|:")
-		if colons == 3
-			then output := split_text(string+splits[2]+final_num+":", match:",|:")
-		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
-		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
-		
-		output
-	}
-	alt_symbol := {
-		alt_array := alt_rarity_color()
-		symbol_variation(
-			symbol:set.symbol,
-			border_radius: alt_array.12,
-			fill_type: "linear gradient",
-			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
-			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
-			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
-			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
-			center_x:0.5, center_y:0.5, end_x:1, end_y:1
+	alt_rarity := {styling.alt_rarity_color}
+	
+	### Customize fonts
+	swap_font := {styling.apply_custom_fonts}
+	name_font := {
+		swap_font_name(
+			src:styling.custom_name_font, 
+			font_name: "Beleren Bold"
 		)
 	}
+	name_font_size := {
+		swap_font_size(
+			src:styling.custom_name_font, 
+			font_size: 16
+		) - shrink_name()
+	}
+	name_font_color := {
+		swap_font_color(
+			src: styling.custom_name_font,
+			font_color: "black"
+		)
+	}
+	name_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_name_font
+		)
+	}
+	name_font_italic := {
+		swap_font_italic(
+			src: styling.custom_name_font
+		)
+	}
+	
+	name2_font := {
+		swap_font_name(
+			src:styling.custom_name_2_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	name2_font_size := {
+		swap_font_size(
+			src:styling.custom_name_2_font, 
+			font_size: 12
+		) - shrink_name2()
+	}
+	name2_font_color := {
+		swap_font_color(
+			src: styling.custom_name_2_font,
+			font_color: "white"
+		)
+	}
+	name2_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_name_2_font
+		)
+	}
+	name2_font_italic := {
+		swap_font_italic(
+			src: styling.custom_name_2_font
+		)
+	}
+	
+	type_font := {
+		swap_font_name(
+			src:styling.custom_type_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	type_font_size := {
+		swap_font_size(
+			src:styling.custom_type_font, 
+			font_size: 13
+		) - shrink_type()
+	}
+	type_font_color := {
+		swap_font_color(
+			src: styling.custom_type_font,
+			font_color: "black"
+		)
+	}
+	type_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_type_font
+		)
+	}
+	type_font_italic := {
+		swap_font_italic(
+			src: styling.custom_type_font
+		)
+	}
+	
+	type2_font := {
+		swap_font_name(
+			src:styling.custom_type_2_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	type2_font_size := {
+		swap_font_size(
+			src:styling.custom_type_2_font, 
+			font_size: 11
+		) - shrink_type2()
+	}
+	type2_font_color := {
+		swap_font_color(
+			src: styling.custom_type_2_font,
+			font_color: "white"
+		)
+	}
+	type2_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_type_2_font
+		)
+	}
+	type2_font_italic := {
+		swap_font_italic(
+			src: styling.custom_type_2_font
+		)
+	}
+	
+	body_font := {
+		swap_font_name(
+			src:styling.custom_body_font, 
+			font_name: "MPlantin"
+		)
+	}
+	body_font_size := {
+		swap_font_size(
+			src:styling.custom_body_font, 
+			font_size: 13
+		)
+	}
+	body_font_color := {
+		swap_font_color(
+			src: styling.custom_body_font,
+			font_color: "black"
+		)
+	}
+	body_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_body_font
+		)
+	}
+	body_font_italic := {
+		swap_font_italic(
+			src: styling.custom_body_font
+		)
+	}
+
+	pt_font := {
+		swap_font_name(
+			src:styling.custom_pt_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	pt_font_size := {
+		swap_font_size(
+			src:styling.custom_pt_font, 
+			font_size: 16
+		)
+	}
+	pt_font_color := {
+		swap_font_color(
+			src: styling.custom_pt_font,
+			font_color: if is_vehicle() then "white" else "black"
+		)
+	}
+	pt_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_pt_font
+		)
+	}
+	pt_font_italic := {
+		swap_font_italic(
+			src: styling.custom_pt_font
+		)
+	}
+
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -223,6 +363,35 @@ styling field:
 	type: text
 	name: alt rarity color
 	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
+styling field:
+	type: boolean
+	name: apply custom fonts
+	description: Enable to attempt to use custom fonts given below
+	initial: no
+styling field:
+	type: text
+	name: custom name font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom type font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom body font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom pt font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom name 2 font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom type 2 font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
 styling field:
 	type: boolean
 	name: grey hybrid name
@@ -339,27 +508,29 @@ card style:
 	############################# Name line
 	name:
 		left: { (if is_spot() then 22 else 0) + (if card.card_symbol=="none" then 32 else 50) }
-		top: 30
+		top: {30 + name_font_vertical()}
 		right:  { 341 - card_style.casting_cost.content_width }
 		height: { 23 - 0.5*shrink_name() }
 		alignment: bottom shrink-overflow
 		padding bottom: 0
 		z index: 1
 		font:
-			name: Beleren Bold
-			size: {16 - shrink_name() }
-			color: black
+			name: { name_font() }
+			italic name: { name_font_italic() }
+			size: { name_font_size() }
+			color: { name_font_color() }
 	name 2:
 		left: { if is_reversed() then 197 else 32}
-		top: { 328 + (if is_spot() then 2 else 0)}
+		top: { 328 + (if is_spot() then 2 else 0)+ name2_font_vertical()}
 		right: { (if is_reversed() then 28 else 178) - card_style.casting_cost_2.content_width }
 		height: { 20 - shrink_name2() }
 		alignment: bottom shrink-overflow
 		z index: 2
 		font:
-			name: Beleren Bold
-			size: {12 - shrink_name2() }
-			color: white
+			name: { name2_font() }
+			italic name: { name2_font_italic() }
+			size: { name2_font_size() }
+			color: { name2_font_color() }
 	alias: 
 		left: {if is_skinned() then 45 else 33}
 		top: 53
@@ -434,15 +605,16 @@ card style:
 	type:
 		left: { (if is_spot() then 50 else 0) + (if has_identity() then (if is_spot() then 50 else 52) else 32) }
 		top: { shrink_type() + if is_spot() then 298 else 296}
-		width: { (if has_identity() then "290" else "310") - max(22,card_style.rarity.content_width) - (if is_spot() then 73 else 0) }
+		width: { (if has_identity() then "290" else "310") - rare_width() - (if is_spot() then 73 else 0) }
 		height: { 20 - shrink_type() }
 		alignment: { if is_spot() then "top center shrink-overflow" else "top shrink-overflow"}
 		z index: 1
 		padding top: 2
 		font:
-			name: Beleren Bold
-			size: { 13 - shrink_type() }
-			color: black
+			name: { type_font() }
+			italic name: { type_font_italic() }
+			size: { type_font_size() }
+			color: { type_font_color() }
 			separator color: red
 	indicator 2:
 		left: {(if is_reversed() then 165 else 0) + (if has_identity2() then 30 else 0)}
@@ -462,9 +634,10 @@ card style:
 		z index: 1
 		padding top: 2
 		font:
-			name: Beleren Bold
-			size: { 11 - shrink_type2() }
-			color: white
+			name: { type2_font() }
+			italic name: { type2_font_italic() }
+			size: { type2_font_size() }
+			color: { type2_font_color() }
 			separator color: red
 	rarity:
 		right: { if is_spot() then 342 else 344}
@@ -479,34 +652,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:
@@ -515,15 +688,15 @@ card style:
 	############################# Text box
 	text:
 		left: {if is_reversed() then 27 else 200}
-		top: { 328 + to_int(chop_top()) }
+		top: { 328 + to_int(chop_top()) + body_font_vertical() }
 		width: {if is_reversed() then 157 else 143}
 		bottom: { (if is_spot() then 464 else 481) - to_int(chop_bot()) }
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: 13
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: black
+			color: { body_font_color() }
 		symbol font:
 			name: { styling.text_box_mana_symbols }
 			size: 13
@@ -546,15 +719,15 @@ card style:
 		line height line max: 1.6
 	text 2:
 		left: {if is_reversed() then 190 else 29}
-		top: { 375 + to_int(back_chop_top()) }
+		top: { 375 + to_int(back_chop_top()) + body_font_vertical()}
 		width: 157
 		bottom: { (if is_spot() then 464 else 481) - to_int(back_chop_bot()) }
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: 14
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: black
+			color: { body_font_color() }
 		symbol font:
 			name: { styling.text_box_mana_symbols }
 			size: 14
@@ -599,14 +772,15 @@ card style:
 	pt:
 		z index: 2
 		left: { if is_spot() then 293 else 286}
-		top: {if is_spot() then 466 else 469}
+		top: {(if is_spot() then 466 else 469)+(pt_font_vertical())}
 		width: 60
 		height:	28
 		alignment: center middle shrink-overflow
 		font:
-			name: Beleren Bold
-			size: 16
-			color: {if is_vehicle() then "white" else "black"}
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {pt_font_size()}
+			color: {pt_font_color()}
 			separator color: red
 	############################# Card sorting / numbering
 	set code:

--- a/data/magic-m15-adventure.mse-style/style
+++ b/data/magic-m15-adventure.mse-style/style
@@ -111,6 +111,46 @@ init script:
 	is_skinned := {contains(styling.other_options, match:"godzilla style alias")}
 
 	card_shape := {"adventure"}
+	
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color != ""}
+	alt_rarity_color := {
+		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
+		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
+		colons := length(filter_text(string, match:":"))
+		output := split_text(string, match:",|:")
+		splits := split_text(string, match:":")
+		final_num := to_real(splits[length(splits)-2]) or else 0
+		final_border := final_num > 0 and final_num < 1
+		final_num := if not final_border then "0.07" else to_string(final_num);
+		if final_border then (
+			colons := colons - 1;
+			string := replace(string, match:"{final_num}:", replace:"")
+		)
+		if colons == 4
+			then output := split_text(string+final_num+":", match:",|:")
+		if colons == 3
+			then output := split_text(string+splits[2]+final_num+":", match:",|:")
+		else if colons == 2
+			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
+		else if colons == 1
+			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
+		
+		output
+	}
+	alt_symbol := {
+		alt_array := alt_rarity_color()
+		symbol_variation(
+			symbol:set.symbol,
+			border_radius: alt_array.12,
+			fill_type: "linear gradient",
+			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
+			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
+			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
+			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
+			center_x:0.5, center_y:0.5, end_x:1, end_y:1
+		)
+	}
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -179,6 +219,10 @@ styling field:
 	type: boolean
 	name: use holofoil stamps
 	description: Use holofoil stamps on rares and mythics
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: boolean
 	name: grey hybrid name
@@ -435,28 +479,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-aftermath.mse-style/style
+++ b/data/magic-m15-aftermath.mse-style/style
@@ -71,6 +71,45 @@ init script:
 	use_main_rarity := { contains(set.mainframe_rarity_name, match: ".png")}
 	un_png := replace@(match:".png", replace: "")
 
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color != ""}
+	alt_rarity_color := {
+		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
+		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
+		colons := length(filter_text(string, match:":"))
+		output := split_text(string, match:",|:")
+		splits := split_text(string, match:":")
+		final_num := to_real(splits[length(splits)-2]) or else 0
+		final_border := final_num > 0 and final_num < 1
+		final_num := if not final_border then "0.07" else to_string(final_num);
+		if final_border then (
+			colons := colons - 1;
+			string := replace(string, match:"{final_num}:", replace:"")
+		)
+		if colons == 4
+			then output := split_text(string+final_num+":", match:",|:")
+		if colons == 3
+			then output := split_text(string+splits[2]+final_num+":", match:",|:")
+		else if colons == 2
+			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
+		else if colons == 1
+			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
+		
+		output
+	}
+	alt_symbol := {
+		alt_array := alt_rarity_color()
+		symbol_variation(
+			symbol:set.symbol,
+			border_radius: alt_array.12,
+			fill_type: "linear gradient",
+			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
+			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
+			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
+			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
+			center_x:0.5, center_y:0.5, end_x:1, end_y:1
+		)
+	}
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -143,6 +182,10 @@ styling field:
 	name: holofoil stamps
 	description: Should rares have holofoil stamps?
 	initial: yes
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: boolean
 	name: promo
@@ -362,28 +405,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-aftermath.mse-style/style
+++ b/data/magic-m15-aftermath.mse-style/style
@@ -6,7 +6,7 @@ icon: card-sample.png
 installer group: magic/m15 style/split cards/fuse
 position hint: 011
 
-version: 2018-06-01
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -72,44 +72,8 @@ init script:
 	un_png := replace@(match:".png", replace: "")
 
 	# alternate rarity color
-	alt_rarity := {styling.alt_rarity_color != ""}
-	alt_rarity_color := {
-		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
-		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
-		colons := length(filter_text(string, match:":"))
-		output := split_text(string, match:",|:")
-		splits := split_text(string, match:":")
-		final_num := to_real(splits[length(splits)-2]) or else 0
-		final_border := final_num > 0 and final_num < 1
-		final_num := if not final_border then "0.07" else to_string(final_num);
-		if final_border then (
-			colons := colons - 1;
-			string := replace(string, match:"{final_num}:", replace:"")
-		)
-		if colons == 4
-			then output := split_text(string+final_num+":", match:",|:")
-		if colons == 3
-			then output := split_text(string+splits[2]+final_num+":", match:",|:")
-		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
-		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
-		
-		output
-	}
-	alt_symbol := {
-		alt_array := alt_rarity_color()
-		symbol_variation(
-			symbol:set.symbol,
-			border_radius: alt_array.12,
-			fill_type: "linear gradient",
-			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
-			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
-			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
-			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
-			center_x:0.5, center_y:0.5, end_x:1, end_y:1
-		)
-	}
+	alt_rarity := {styling.alt_rarity_color}
+
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -368,7 +332,7 @@ card style:
 	type:
 		left: { if has_identity() then "50" else "30" }
 		top: 185
-		width: { (if has_identity() then "290" else "310") - max(22,card_style.rarity.content_width) }
+		width: { (if has_identity() then "290" else "310") - rare_width() }
 		height: 20
 		alignment: top shrink-overflow
 		z index: 1
@@ -405,34 +369,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-altered.mse-style/style
+++ b/data/magic-m15-altered.mse-style/style
@@ -197,6 +197,7 @@ init script:
 
 	center_map := {is_map() and (card.casting_cost == "" or chosen(styling.other_options, choice:"always center map names"))}
 	use_evobar := {chosen(styling.other_options, choice:"pokemon evobar")}
+	# alternate rarity color
 	alt_rarity := {styling.alt_rarity_color != ""}
 	alt_rarity_color := {
 		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
@@ -204,18 +205,37 @@ init script:
 		colons := length(filter_text(string, match:":"))
 		output := split_text(string, match:",|:")
 		splits := split_text(string, match:":")
+		final_num := to_real(splits[length(splits)-2]) or else 0
+		final_border := final_num > 0 and final_num < 1
+		final_num := if not final_border then "0.07" else to_string(final_num);
+		if final_border then (
+			colons := colons - 1;
+			string := replace(string, match:"{final_num}:", replace:"")
+		)
 		if colons == 4
-			then output := split_text(string+"0.07:", match:",|:")
+			then output := split_text(string+final_num+":", match:",|:")
 		if colons == 3
-			then output := split_text(string+splits[2]+"0.07:", match:",|:")
+			then output := split_text(string+splits[2]+final_num+":", match:",|:")
 		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:0.07:", match:",|:")
+			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
 		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:0.07:", match:",|:")
-
+			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
+		
 		output
 	}
-	alt_symbol := {symbol_variation(symbol:set.symbol, border_radius: alt_rarity_color().12, fill_type: "linear gradient", fill_color_1: rgb(alt_rarity_color().0, alt_rarity_color().1, alt_rarity_color().2), fill_color_2: rgb(alt_rarity_color().3, alt_rarity_color().4, alt_rarity_color().5), border_color_1: rgb(alt_rarity_color().6, alt_rarity_color().7, alt_rarity_color().8), border_color_2: rgb(alt_rarity_color().9, alt_rarity_color().10, alt_rarity_color().11), center_x:0.5, center_y:0.5, end_x:1, end_y:1)}
+	alt_symbol := {
+		alt_array := alt_rarity_color()
+		symbol_variation(
+			symbol:set.symbol,
+			border_radius: alt_array.12,
+			fill_type: "linear gradient",
+			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
+			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
+			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
+			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
+			center_x:0.5, center_y:0.5, end_x:1, end_y:1
+		)
+	}
 	is_skinned := {chosen(styling.other_options, choice:"godzilla style alias")}
 	use_vorthos := {((not is_leveler() or lone_pt()) and card.pt != "") or chosen(styling.other_options, choice:"vorthos box")}
 	clear_tops := {chosen(styling.other_options, choice:"clear tops") and not is_puma()}
@@ -433,7 +453,7 @@ styling field:
 styling field:
 	type: text
 	name: alt rarity color
-	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:..." 1 and 2 are fill color, 3 and 4 border color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: text
 	name: card watermark

--- a/data/magic-m15-altered.mse-style/style
+++ b/data/magic-m15-altered.mse-style/style
@@ -6,7 +6,7 @@ icon: card-sample.png
 installer group: magic/m15 style/normal cards
 position hint: 001
 
-version: 2023-02-13
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2020-04-25
@@ -198,44 +198,8 @@ init script:
 	center_map := {is_map() and (card.casting_cost == "" or chosen(styling.other_options, choice:"always center map names"))}
 	use_evobar := {chosen(styling.other_options, choice:"pokemon evobar")}
 	# alternate rarity color
-	alt_rarity := {styling.alt_rarity_color != ""}
-	alt_rarity_color := {
-		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
-		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
-		colons := length(filter_text(string, match:":"))
-		output := split_text(string, match:",|:")
-		splits := split_text(string, match:":")
-		final_num := to_real(splits[length(splits)-2]) or else 0
-		final_border := final_num > 0 and final_num < 1
-		final_num := if not final_border then "0.07" else to_string(final_num);
-		if final_border then (
-			colons := colons - 1;
-			string := replace(string, match:"{final_num}:", replace:"")
-		)
-		if colons == 4
-			then output := split_text(string+final_num+":", match:",|:")
-		if colons == 3
-			then output := split_text(string+splits[2]+final_num+":", match:",|:")
-		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
-		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
-		
-		output
-	}
-	alt_symbol := {
-		alt_array := alt_rarity_color()
-		symbol_variation(
-			symbol:set.symbol,
-			border_radius: alt_array.12,
-			fill_type: "linear gradient",
-			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
-			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
-			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
-			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
-			center_x:0.5, center_y:0.5, end_x:1, end_y:1
-		)
-	}
+	alt_rarity := {styling.alt_rarity_color}
+
 	is_skinned := {chosen(styling.other_options, choice:"godzilla style alias")}
 	use_vorthos := {((not is_leveler() or lone_pt()) and card.pt != "") or chosen(styling.other_options, choice:"vorthos box")}
 	clear_tops := {chosen(styling.other_options, choice:"clear tops") and not is_puma()}
@@ -243,7 +207,7 @@ init script:
 	pure_snow := {is_snow() and not is_fnm() and not is_inverted() and not is_full_art() and not is_leveler() and not is_shifted()}
 	chop_top := {if styling.chop_top == "" then 0 else if comma_count(styling.chop_top) == "," or comma_count(styling.chop_top) == ",," then split_text(match:",", styling.chop_top).0 else styling.chop_top}
 	chop_bot := {if comma_count(styling.chop_top) == ",," then split_text(match:",", styling.chop_top).1 else if styling.chop_bottom == "" then 0 else styling.chop_bottom}
-	top_of_textbox := {(if is_map() then 340 else if is_full_art() then 359 else if is_mutate() then 395 else 327) - (-chop_top()) }
+	top_of_textbox := {(if is_map() then 340 else if is_full_art() then 359 else if is_mutate() then 395 else 327) - (-chop_top()) + body_font_vertical()}
 	bottom_of_textbox := {(if is_map() then 475 else 481) - chop_bot() }
 
 	is_leveler := {chosen(styling.frames, choice:"leveler")}
@@ -300,7 +264,136 @@ init script:
 		cw := if cw > 44 then (if set.print_fix != "" then set.print_fix else 22) else if cw < 22 then 22 else cw
 		if card_style.rarity.width == 0 then 0 else cw
 	}
+	
+	### Customize fonts
+	swap_font := {styling.apply_custom_fonts}
+	name_font := {
+		swap_font_name(
+			src:styling.custom_name_font, 
+			font_name: if is_map() then "Beleren Small Caps" else "Beleren Bold"
+		)
+	}
+	name_font_size := {
+		swap_font_size(
+			src:styling.custom_name_font, 
+			font_size: if is_map() then 14.8 else 16
+		) - shrink_name()
+	}
+	name_font_color := {
+		swap_font_color(
+			src: styling.custom_name_font,
+			font_color: if is_shifted() or is_fnm() or is_inverted() then "white" else "black"
+		)
+	}
+	name_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_name_font
+		)
+	}
+	name_font_italic := {
+		swap_font_italic(
+			src: styling.custom_name_font
+		)
+	}
+	
+	type_font := {
+		swap_font_name(
+			src:styling.custom_type_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	type_font_size := {
+		swap_font_size(
+			src:styling.custom_type_font, 
+			font_size: if is_map() then 12 else 13
+		) - shrink_type()
+	}
+	type_font_color := {
+		swap_font_color(
+			src: styling.custom_type_font,
+			font_color: if is_full_art() or is_puma() or is_shifted() or is_fnm() or is_inverted() then "white" else "black"
+		)
+	}
+	type_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_type_font
+		)
+	}
+	type_font_italic := {
+		swap_font_italic(
+			src: styling.custom_type_font
+		)
+	}
+	
+	body_font := {
+		swap_font_name(
+			src:styling.custom_body_font, 
+			font_name: "MPlantin"
+		)
+	}
+	body_font_size := {
+		swap_font_size(
+			src:styling.custom_body_font, 
+			font_size: if styling.font_cap != "" then to_number(styling.font_cap) else if is_mutate() then 12 else 14
+		)
+	}
+	body_font_color := {
+		swap_font_color(
+			src: styling.custom_body_font,
+			font_color: if is_full_art() or is_fnm() or is_inverted() then "white" else "black"
+		)
+	}
+	body_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_body_font
+		)
+	}
+	body_font_italic := {
+		swap_font_italic(
+			src: styling.custom_body_font
+		)
+	}
 
+	pt_font := {
+		swap_font_name(
+			src:styling.custom_pt_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	loyalty_font_size := {
+		swap_font_size(
+			src:styling.custom_pt_font, 
+			font_size: 14
+		)
+	}
+	loyalty_font_color := {
+		swap_font_color(
+			src: styling.custom_pt_font,
+			font_color: "white"
+		)
+	}
+	pt_font_size := {
+		swap_font_size(
+			src:styling.custom_pt_font, 
+			font_size: if is_map() then 14 else 16
+		)
+	}
+	pt_font_color := {
+		swap_font_color(
+			src: styling.custom_pt_font,
+			font_color: if is_shifted() or is_fnm() or is_inverted() then "white" else if is_vehicle() and (not is_legend() or chosen(styling.other_options, choice:"brown legendary vehicle pt")) then "white" else "black"
+		)
+	}
+	pt_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_pt_font
+		)
+	}
+	pt_font_italic := {
+		swap_font_italic(
+			src: styling.custom_pt_font
+		)
+	}
 
 	use_flash_dot := {false}
 ############################################################## Set info fields
@@ -446,18 +539,34 @@ styling field:
 	description: Use the color indicator dot
 	initial: no
 styling field:
-	type: boolean
-	name: remove from autocount
-	description: Removes the automatic card number for specific cards, to allow for overcounted cards like in Planeswalker Decks.
-	initial: no
+	type: text
+	name: card watermark
+	description: Filename in magic-watermarks to use for standalone card watermark
 styling field:
 	type: text
 	name: alt rarity color
 	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
+	type: boolean
+	name: apply custom fonts
+	description: Enable to attempt to use custom fonts given below
+	initial: no
+styling field:
 	type: text
-	name: card watermark
-	description: Filename in magic-watermarks to use for standalone card watermark
+	name: custom name font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom type font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom body font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom pt font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
 styling field:
 	type: choice
 	name: hybrid name
@@ -465,6 +574,11 @@ styling field:
 	choice: gold
 	choice: hybrid
 	description: Use a grey background for the name and type line on hybrid cards like real cards, or gold or hybrid instead.
+styling field:
+	type: boolean
+	name: remove from autocount
+	description: Removes the automatic card number for specific cards, to allow for overcounted cards like in Planeswalker Decks.
+	initial: no
 styling field:
 	type: boolean
 	name: colored multicolor land name
@@ -571,16 +685,18 @@ card style:
 	############################# Name line
 	name:
 		left: { if center_map() then 55 else if is_map() then (if use_node() then 65 else 60) else if use_node() then 58 else if card.card_symbol=="none" then 32 else 50 }
-		top: { if is_map() then 27 else if is_devoid() then 30 else if is_clear() or clear_tops() then 31 else 30 }
+		top: { (if is_map() then 27 else if is_devoid() then 30 else if is_clear() or clear_tops() then 31 else 30)+ name_font_vertical() }
 		right:  { if center_map() then 320 else (if is_map() then 320 else 341) - card_style.casting_cost.content_width }
 		height: { 23 - (0.5 * shrink_name()) }
 		alignment: {if center_map() then "center bottom shrink-overflow" else "left bottom shrink-overflow" }
 		padding bottom: 0
 		z index: 2
 		font:
-			name: { if is_map() then "Beleren Small Caps" else "Beleren Bold" }
-			size: { (if is_map() then 14.8 else 16) - shrink_name() }
-			color: {if is_shifted() or is_fnm() or is_inverted() then "white" else "black"}
+		font:
+			name: { name_font() }
+			italic name: { name_font_italic() }
+			size: { name_font_size() }
+			color: { name_font_color() }
 			shadow color: {if is_shifted() or is_fnm() then rgb(0,0,0) else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -650,16 +766,17 @@ card style:
 		image: { card_identity() }
 	type:
 		left: { if is_map() then 85 else (if use_flash_dot() then 3 else 0) + if is_season() then (if styling.color_indicator_dot then 64 else 44)+(if is_clear() then 4 else 0) else (if styling.color_indicator_dot then 52 else 32) + (if is_clear() then 4 else 0) }
-		top: { (if is_map() then 297.5 else if is_clear() then 294 else if is_thbland() then 444 else if is_full_art() then 329 else 296) + shrink_type() }
+		top: { (if is_map() then 297.5 else if is_clear() then 294 else if is_thbland() then 444 else if is_full_art() then 329 else 296) + shrink_type() + type_font_vertical() }
 		width: { if is_map() then 205 else (if styling.color_indicator_dot then "290" else "310") - rare_width() - (if is_season() then 12 else 0) }
 		height: { (if is_map() then 18 else 20) - shrink_type() }
 		alignment: { if is_map() then "center top shrink-overflow" else "top shrink-overflow"}
 		z index: 5
 		padding top: 2
 		font:
-			name: Beleren Bold
-			size: { (if is_map() then 12 else 13) - shrink_type() }
-			color: { if is_full_art() or is_puma() or is_shifted() or is_fnm() or is_inverted() then "white" else "black"}
+			name: { type_font() }
+			italic name: { type_font_italic() }
+			size: { type_font_size() }
+			color: { type_font_color() }
 			shadow color: {if is_full_art() or is_puma() or is_shifted() or is_fnm() then "black" else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -677,34 +794,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:
@@ -717,11 +834,11 @@ card style:
 		width: { if is_leveler() then 0 else (if(card.level_0 != "" or card.level_1 != "" or card.level_2 != "") then -46 else 0) + if is_map() then 287 else 314 }
 		bottom: { bottom_of_textbox() }
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: {if styling.font_cap != "" then to_number(styling.font_cap) else (if is_mutate() then 12 else 14)}
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: { if is_full_art() or is_fnm() or is_inverted() then "white" else "black"}
+			color: { body_font_color() }
 			shadow color: {if is_full_art() or is_fnm() then "black" else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -754,11 +871,12 @@ card style:
 		right: { if is_leveler() then (if lone_pt() or card.pt == "" then 342 else 277) else if is_mutate() then 342 else if is_map() then 40 else 29}
 		bottom: { if is_mutate() then 392 else if is_leveler() then (327+lv_1_height()) else bottom_of_textbox() }
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: {if styling.font_cap != "" then to_number(styling.font_cap) else 14}
+		font:
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: { if is_full_art() or is_fnm() or is_inverted() then "white" else "black"}
+			color: { body_font_color() }
 			shadow color: {if is_full_art() or is_fnm() then "black" else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -789,11 +907,11 @@ card style:
 		right: { if is_leveler() then (if card.pt_2 != "" then 277 else 342) else 0 }
 		bottom: { if is_leveler() then (329 + lv_2_coordinate()) + lv_2_height()-2 else 0 }
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: {if styling.font_cap != "" then to_number(styling.font_cap) else 14}
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: { if is_full_art() or is_fnm() or is_inverted() then "white" else "black"}
+			color: { body_font_color() }
 			shadow color: {if is_full_art() or is_fnm() then "black" else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -824,11 +942,11 @@ card style:
 		right: {if card.pt_3 != "" then 277 else 342}
 		height: {if not is_leveler()then 0 else lv_3_height()-2}
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: {if styling.font_cap != "" then to_number(styling.font_cap) else 14}
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: { if is_full_art() or is_fnm() or is_inverted() then "white" else "black"}
+			color: { body_font_color() }
 			shadow color: {if is_full_art() or is_fnm() then "black" else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -859,11 +977,11 @@ card style:
 		right: {if card.pt_7 != "" then 277 else 342}
 		height: {if not is_leveler() then 0 else lv_4_height()-2}
 		font:
-			name: MPlantin
-			italic name: MPlantin-Italic
-			size: {if styling.font_cap != "" then to_number(styling.font_cap) else 14}
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
 			scale down to: 6
-			color: { if is_full_art() or is_fnm() then "white" else "black"}
+			color: { body_font_color() }
 			shadow color: {if is_full_art() or is_fnm() then "black" else rgba(0,0,0,0)}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -971,14 +1089,15 @@ card style:
 	pt:
 		z index: 4
 		left: {if is_leveler() and not lone_pt() then 291 else 286}
-		top: { if is_leveler() and not lone_pt() then (l1_center() - 14) else if is_map() then 467 else 469}
+		top: { (if is_leveler() and not lone_pt() then (l1_center() - 14) else if is_map() then 467 else 469)+(pt_font_vertical())}
 		width: {if starting_loyalty() and not is_leveler() then 0 else 60}
 		height:	28
 		alignment: center middle shrink-overflow
 		font:
-			name: Beleren Bold
-			size: {if is_map() then 14 else 16}
-			color: {if is_shifted() or is_fnm() or is_inverted() then "white" else if is_vehicle() and (not is_legend() or chosen(styling.other_options, choice:"brown legendary vehicle pt")) then "white" else "black"}
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {pt_font_size()}
+			color: {pt_font_color()}
 			separator color: red
 			shadow color: {if is_shifted() or is_fnm() then rgb(0,0,0) else rgba(0,0,0,0)}
 			shadow displacement x: -1
@@ -987,14 +1106,15 @@ card style:
 	pt 2:
 		z index: 4
 		left: 291
-		top: {(l2_center() - 12)}
+		top: {(l2_center() - 12)+(pt_font_vertical())}
 		width: {if is_leveler() and not lone_pt() or card.pt_2 != "" then 60 else 0}
 		height: 28
 		alignment: center middle shrink-overflow
 		font:
-			name: Beleren Bold
-			size: {if is_map() then 14 else 16}
-			color: {if is_shifted() or is_fnm() or is_inverted() then "white" else if is_vehicle() and (not is_legend() or chosen(styling.other_options, choice:"brown legendary vehicle pt")) then "white" else "black"}
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {pt_font_size()}
+			color: {pt_font_color()}
 			separator color: red
 			shadow color: {if is_shifted() or is_fnm() then rgb(0,0,0) else rgba(0,0,0,0)}
 			shadow displacement x: -1
@@ -1002,14 +1122,15 @@ card style:
 	pt 3:
 		z index: 4
 		left: 291
-		top: {(l3_center() - 12)}
+		top: {(l3_center() - 12)+(pt_font_vertical())}
 		width: {if is_leveler() and not lone_pt() or card.pt_3 != "" then 60 else 0}
 		height: 28
 		alignment: center middle shrink-overflow
 		font:
-			name: Beleren Bold
-			size: {if is_map() then 14 else 16}
-			color: {if is_shifted() or is_fnm() or is_inverted() then "white" else if is_vehicle() and (not is_legend() or chosen(styling.other_options, choice:"brown legendary vehicle pt")) then "white" else "black"}
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {pt_font_size()}
+			color: {pt_font_color()}
 			separator color: red
 			shadow color: {if is_shifted() or is_fnm() then rgb(0,0,0) else rgba(0,0,0,0)}
 			shadow displacement x: -1
@@ -1017,14 +1138,15 @@ card style:
 	pt 7:
 		z index: 4
 		left: 291
-		top: {(l4_center() - 12)}
+		top: {(l4_center() - 12)+(pt_font_vertical())}
 		width: {if is_leveler() and not lone_pt() or card.pt_7 != "" then 60 else 0}
 		height: {if card_style.level_4_text.height < 10 and card.pt_7 == "" then 0 else 28}
 		alignment: center middle shrink-overflow
 		font:
-			name: Beleren Bold
-			size: {if is_map() then 14 else 16}
-			color: {if is_shifted() or is_fnm() then "white" else if is_vehicle() and (not is_legend() or chosen(styling.other_options, choice:"brown legendary vehicle pt")) then "white" else "black"}
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {pt_font_size()}
+			color: {pt_font_color()}
 			separator color: red
 			shadow color: {if is_shifted() or is_fnm() then rgb(0,0,0) else rgba(0,0,0,0)}
 			shadow displacement x: -1
@@ -1032,14 +1154,15 @@ card style:
 	loyalty:
 		z index: 7
 		left: 326
-		top: 468
+		top: {468+(pt_font_vertical())}
 		width: {if starting_loyalty() then 13.16 else 0}
 		height:	34.63
 		alignment: center middle
 		font:
-			name: Beleren Bold
-			size: 14
-			color: white
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {loyalty_font_size()}
+			color: {loyalty_font_color()}
 	############################# Card sorting / numbering
 	set code:
 		left: 24

--- a/data/magic-m15-future.mse-style/style
+++ b/data/magic-m15-future.mse-style/style
@@ -124,6 +124,10 @@ init script:
 	chop_top := {if styling.chop_top == "" then 0 else if comma_count(styling.chop_top) == "," or comma_count(styling.chop_top) == ",," then split_text(match:",", styling.chop_top).0 else styling.chop_top}
 	chop_bot := {if comma_count(styling.chop_top) == ",," then split_text(match:",", styling.chop_top).1 else if styling.chop_bottom == "" then 0 else styling.chop_bottom}
 
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color}
+	
+
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -156,6 +160,10 @@ styling field:
 	name: beleren
 	description: Should these cards use Beleren or the original font?
 	initial: yes
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: boolean
 	name: shifted sorting
@@ -385,28 +393,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-mainframe-dfc.mse-style/style
+++ b/data/magic-m15-mainframe-dfc.mse-style/style
@@ -6,7 +6,7 @@ installer group: magic/m15 style/double-faced cards
 icon: card-sample.png
 position hint: 005
 
-version: 2020-09-04
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -754,44 +754,8 @@ init script:
 	shown_cr := {if set.automatic_copyright then set.copyright != "" else card.copyright != ""}
 
 	# alternate rarity color
-	alt_rarity := {styling.alt_rarity_color != ""}
-	alt_rarity_color := {
-		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
-		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
-		colons := length(filter_text(string, match:":"))
-		output := split_text(string, match:",|:")
-		splits := split_text(string, match:":")
-		final_num := to_real(splits[length(splits)-2]) or else 0
-		final_border := final_num > 0 and final_num < 1
-		final_num := if not final_border then "0.07" else to_string(final_num);
-		if final_border then (
-			colons := colons - 1;
-			string := replace(string, match:"{final_num}:", replace:"")
-		)
-		if colons == 4
-			then output := split_text(string+final_num+":", match:",|:")
-		if colons == 3
-			then output := split_text(string+splits[2]+final_num+":", match:",|:")
-		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
-		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
-		
-		output
-	}
-	alt_symbol := {
-		alt_array := alt_rarity_color()
-		symbol_variation(
-			symbol:set.symbol,
-			border_radius: alt_array.12,
-			fill_type: "linear gradient",
-			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
-			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
-			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
-			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
-			center_x:0.5, center_y:0.5, end_x:1, end_y:1
-		)
-	}
+	alt_rarity := {styling.alt_rarity_color}
+
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -1290,7 +1254,7 @@ card style:
 	type:
 		left: { if is_map() then 85 else if has_identity() then "52" else "32" }
 		top: { (if is_map() then 297.5 else if is_saga() or is_class() then 444 else if has_four_abilities() then 261 else 296) + shrink_type() }
-		width: { if is_map() then 205 else (if has_identity() then "290" else "310") - max(22,card_style.rarity.content_width) }
+		width: { if is_map() then 205 else (if has_identity() then "290" else "310") - rare_width() }
 		height: { if is_map() then 18 - shrink_type() else 20 - shrink_type() }
 		alignment: { if is_map() then "center top shrink-overflow" else "top shrink-overflow"}
 		z index: 2
@@ -1305,7 +1269,7 @@ card style:
 	type 2:
 		left: { if back_map() then 462 else if has_identity2() then "429" else "409" }
 		top: { (if back_map() then 297.5 else if back_saga() or back_class() then 444 else if back_four_abilities() then 261 else 296) + shrink_type2() }
-		width: { if back_map() then 205 else (if has_identity2() then "290" else "310") - max(22,card_style.rarity.content_width) }
+		width: { if back_map() then 205 else (if has_identity2() then "290" else "310") - rare_width() }
 		height: { if back_map() then 18 - shrink_type2() else 20 - shrink_type2()}
 		alignment: {if back_map() then "center top shrink-overflow" else "top shrink-overflow"}
 		z index: 2
@@ -1330,34 +1294,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:
@@ -1376,34 +1340,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-mainframe-dfc.mse-style/style
+++ b/data/magic-m15-mainframe-dfc.mse-style/style
@@ -753,6 +753,45 @@ init script:
 	custom_watermark_b := {if styling.card_watermark_2 == "" or not contains(styling.card_watermark_2, match:".png") then "/magic-watermarks.mse-include/planeswalker.png" else "/magic-watermarks.mse-include/" + styling.card_watermark_2}
 	shown_cr := {if set.automatic_copyright then set.copyright != "" else card.copyright != ""}
 
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color != ""}
+	alt_rarity_color := {
+		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
+		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
+		colons := length(filter_text(string, match:":"))
+		output := split_text(string, match:",|:")
+		splits := split_text(string, match:":")
+		final_num := to_real(splits[length(splits)-2]) or else 0
+		final_border := final_num > 0 and final_num < 1
+		final_num := if not final_border then "0.07" else to_string(final_num);
+		if final_border then (
+			colons := colons - 1;
+			string := replace(string, match:"{final_num}:", replace:"")
+		)
+		if colons == 4
+			then output := split_text(string+final_num+":", match:",|:")
+		if colons == 3
+			then output := split_text(string+splits[2]+final_num+":", match:",|:")
+		else if colons == 2
+			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
+		else if colons == 1
+			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
+		
+		output
+	}
+	alt_symbol := {
+		alt_array := alt_rarity_color()
+		symbol_variation(
+			symbol:set.symbol,
+			border_radius: alt_array.12,
+			fill_type: "linear gradient",
+			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
+			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
+			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
+			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
+			center_x:0.5, center_y:0.5, end_x:1, end_y:1
+		)
+	}
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -1054,6 +1093,10 @@ styling field:
 	name: card watermark 2
 	description: Filename in magic-watermarks to use for standalone card watermark
 styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
+styling field:
 	type: boolean
 	name: grey hybrid name
 	description: Use a grey background for the name and type line on hybrid cards. This is done on real cards.
@@ -1287,28 +1330,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:
@@ -1327,28 +1376,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-mainframe-planeswalker.mse-style/style
+++ b/data/magic-m15-mainframe-planeswalker.mse-style/style
@@ -6,7 +6,7 @@ installer group: magic/m15 style/planeswalkers
 icon: card-sample.png
 position hint: 003
 
-version: 2020-03-19
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -231,25 +231,9 @@ init script:
 	}
 	pw_font_size := { if styling.font_size != "" then styling.font_size else 12 }
 	
-	alt_rarity := {styling.alt_rarity_color != ""}
-	alt_rarity_color := {
-		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
-		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
-		colons := length(filter_text(string, match:":"))
-		output := split_text(string, match:",|:")
-		splits := split_text(string, match:":")
-		if colons == 4
-			then output := split_text(string+"0.07:", match:",|:")
-		if colons == 3
-			then output := split_text(string+splits[2]+"0.07:", match:",|:")
-		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:0.07:", match:",|:")
-		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:0.07:", match:",|:")
-		
-		output
-	}
-	alt_symbol := {symbol_variation(symbol:set.symbol, border_radius: alt_rarity_color().12, fill_type: "linear gradient", fill_color_1: rgb(alt_rarity_color().0, alt_rarity_color().1, alt_rarity_color().2), fill_color_2: rgb(alt_rarity_color().3, alt_rarity_color().4, alt_rarity_color().5), border_color_1: rgb(alt_rarity_color().6, alt_rarity_color().7, alt_rarity_color().8), border_color_2: rgb(alt_rarity_color().9, alt_rarity_color().10, alt_rarity_color().11), center_x:0.5, center_y:0.5, end_x:1, end_y:1)}
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color}
+
 	card_shape := {if use_adv() then "adventure" else "planeswalker"}
 	page_image := {
 		page := if has_four_abilities() then card_background_page2() else card_background_page()
@@ -526,7 +510,7 @@ card style:
 	type:
 		left: { if has_identity() then "53" else "33" }
 		top: { (if has_four_abilities() then 261 else 296) + shrink_type() }
-		width: { 309 - max(22,card_style.rarity.content_width) }
+		width: { 309 - rare_width() }
 		height: { 20 - shrink_type() }
 		alignment: top shrink-overflow
 		z index: 2
@@ -549,34 +533,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-mainframe-tokens.mse-style/style
+++ b/data/magic-m15-mainframe-tokens.mse-style/style
@@ -6,7 +6,7 @@ icon: card-sample.png
 installer group: magic/m15 style/tokens
 position hint: 004
 
-version: 2020-05-10
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -109,6 +109,127 @@ init script:
 	white_state_font := {is_weird_token() and contains(styling.other_options, match:"white state text")}
 	archetype_image := {is_archetype() and contains(styling.other_options, match:"archetype image")}
 	use_drop_shadow := {is_weird_token() and contains(styling.other_options, match:"state drop shadow")}
+
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color}
+
+	### Customize fonts
+	swap_font := {styling.apply_custom_fonts}
+	name_font := {
+		swap_font_name(
+			src:styling.custom_name_font, 
+			font_name: if is_archetype() then "Gotham Medium" else if is_copy() or mtgo_abil() then "Beleren Bold" else "Beleren Small Caps Bold"
+		)
+	}
+	name_font_size := {
+		swap_font_size(
+			src:styling.custom_name_font, 
+			font_size: if is_archetype() then 9 else if is_copy() or mtgo_abil() then 18 else 19
+		) - shrink_name()
+	}
+	name_font_color := {
+		swap_font_color(
+			src: styling.custom_name_font,
+			font_color: if is_weird_token() then "white" else if is_m20() and card.card_color == "white" and not is_clear() then "black" else if is_m20() then "white" else rgb(255,239,128)
+		)
+	}
+	name_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_name_font
+		)
+	}
+	name_font_italic := {
+		swap_font_italic(
+			src: styling.custom_name_font
+		)
+	}
+	
+	type_font := {
+		swap_font_name(
+			src:styling.custom_type_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	type_font_size := {
+		swap_font_size(
+			src:styling.custom_type_font, 
+			font_size: 14
+		) - shrink_type()
+	}
+	type_font_color := {
+		swap_font_color(
+			src: styling.custom_type_font,
+			font_color: if mtgo_abil() then rgb(255,239,128) else "black"
+		)
+	}
+	type_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_type_font
+		)
+	}
+	type_font_italic := {
+		swap_font_italic(
+			src: styling.custom_type_font
+		)
+	}
+	
+	body_font := {
+		swap_font_name(
+			src:styling.custom_body_font, 
+			font_name: if is_archetype() then "Gotham Pro" else "MPlantin"
+		)
+	}
+	body_font_size := {
+		swap_font_size(
+			src:styling.custom_body_font, 
+			font_size: if styling.shrink_font_size != "" then 14 - to_number(styling.shrink_font_size) else 14
+		)
+	}
+	body_font_color := {
+		swap_font_color(
+			src: styling.custom_body_font,
+			font_color: if white_state_font() then "white" else "black"
+		)
+	}
+	body_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_body_font
+		)
+	}
+	body_font_italic := {
+		swap_font_italic(
+			src: styling.custom_body_font
+		)
+	}
+
+	pt_font := {
+		swap_font_name(
+			src:styling.custom_pt_font, 
+			font_name: "Beleren Bold"
+		)
+	}
+	pt_font_size := {
+		swap_font_size(
+			src:styling.custom_pt_font, 
+			font_size: 16
+		)
+	}
+	pt_font_color := {
+		swap_font_color(
+			src: styling.custom_pt_font,
+			font_color: if is_vehicle() then "white" else "black"
+		)
+	}
+	pt_font_vertical := {
+		swap_font_vertical(
+			src: styling.custom_pt_font
+		)
+	}
+	pt_font_italic := {
+		swap_font_italic(
+			src: styling.custom_pt_font
+		)
+	}
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -164,6 +285,31 @@ styling field:
 	type: text
 	name: shrink font size
 	description: Reduces the fontsize text N points.
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
+styling field:
+	type: boolean
+	name: apply custom fonts
+	description: Enable to attempt to use custom fonts given below
+	initial: no
+styling field:
+	type: text
+	name: custom name font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom type font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom body font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
+styling field:
+	type: text
+	name: custom pt font
+	description: Formatted as "font name;font size;font color;vertical offset;italic font name" last 4 are optional. color can be a name or R,G,B,A numbers.
 styling field:
 	type: text
 	name: popout image style
@@ -269,7 +415,7 @@ card style:
 	############################# Name line
 	name:
 		left: { if is_copy() then 32 else 30}
-		top: { if is_archetype() then 10 else if is_copy() then 24 else 26}
+		top: { (if is_archetype() then 10 else if is_copy() then 24 else 26) + name_font_vertical()}
 		width: { 315 - (if is_copy() then card_style.casting_cost.content_width else 0)}
 		height: {if is_archetype() then 14 else 28 - (0.5 * shrink_name())}
 		alignment: { if is_copy() or mtgo_abil() then "bottom shrink-overflow" else "bottom center"}
@@ -277,11 +423,11 @@ card style:
 		padding top: 2
 		z index: 5
 		font:
-			name: { if is_archetype() then "Gotham Medium" else if is_copy() or mtgo_abil() then "Beleren Bold" else "Beleren Small Caps Bold" }
-			size: { if is_archetype() then 9 else (if is_copy() or mtgo_abil() then 18 else 19) - shrink_name()}
-			color: {if is_weird_token() then "white" else if is_m20() and card.card_color == "white" and not is_clear() then "black" else if is_m20() then "white" else rgb(255,239,128)}
+			name: { name_font() }
+			italic name: { name_font_italic() }
+			size: { name_font_size() }
+			color: { name_font_color() }
 			weight: {if is_archetype() then "bold" else ""}
-		always symbol: true
 	alias: 
 		left: {if is_skinned() then 45 else 19}
 		top: {if is_m20() and is_skinned() then (if is_legend() then 57 else 51) else 52}
@@ -338,8 +484,9 @@ card style:
 			 else if is_clear() then 354
 			 else 354)
 			 + (if is_m20() and is_textless() then 1 else if is_m20() and not is_tall() then 2 else if is_m20() and is_clear() then 2)
-			 + shrink_type()}
-		width: { if is_weird_token() then 0 else 311 - ( if contains(styling.other_options, match:"remove rarity") then 0 else max(22,card_style.rarity.content_width)) }
+			 + shrink_type()
+			 + type_font_vertical()}
+		width: { if is_weird_token() then 0 else 311 - ( if contains(styling.other_options, match:"remove rarity") then 0 else rare_width()) }
 		height: { 20 - shrink_type()}
 		alignment: top shrink-overflow
 		z index: 2
@@ -347,9 +494,10 @@ card style:
 		padding bottom: 4
 		padding right: 2
 		font:
-			name: Beleren Bold
-			size: { 14 - shrink_type() }
-			color: { if mtgo_abil() then rgb(255,239,128) else "black"}
+			name: { type_font() }
+			italic name: { type_font_italic() }
+			size: { type_font_size() }
+			color: { type_font_color() }
 			separator color: red
 	rarity:
 		right: 344
@@ -371,43 +519,52 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "mp.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.masterpiece_symbol, variation: "mythic rare")
 	############################# Text box
 	text:
 		left: {if is_archetype() then 20 else 29}
 		top:
 			{ 
-				if is_archetype() then 30
+				(if is_archetype() then 30
 				else if is_state() then 327
 				else if is_tall() then 327
 				else if is_textless() then 459
-				else 388}
+				else 388)
+				+ body_font_vertical()
+			}
 		width: { if is_archetype() then 337 else 315}
 		height:
 			{ 
@@ -415,13 +572,14 @@ card style:
 				else if is_state() then 154
 				else if is_tall() then 154
 				else if is_textless() then 27
-				else 94}
+				else 94
+			}
 		font:
-			name: {if is_archetype() then "Gotham Pro" else "MPlantin"}
-			italic name: MPlantin-Italic
-			size: { if styling.shrink_font_size != "" then 14 - to_number(styling.shrink_font_size) else 14}
-			scale down to: 8
-			color: {if white_state_font() then "white" else "black"}
+			name: { body_font() }
+			italic name: { body_font_italic() }
+			size: { body_font_size() }
+			scale down to: 6
+			color: { body_font_color() }
 			shadow color: {if not use_drop_shadow() then rgba(0,0,0,0) else if white_state_font() then "black" else "white"}
 			shadow displacement x: -1
 			shadow displacement y: 1
@@ -501,14 +659,15 @@ card style:
 	pt:
 		z index: 2
 		left: { if center_pt() then 157.5 else 286}
-		top: 469
+		top: {469 + pt_font_vertical()}
 		width:	60
 		height:	28
 		alignment: center middle shrink-overflow
 		font:
-			name: Beleren Bold
-			size: 16
-			color: {if is_vehicle() then "white" else "black"}
+			name: {pt_font()}
+			italic name: {pt_font_italic()}
+			size: {pt_font_size()}
+			color: {pt_font_color()}
 			separator color: red
 	############################# Card sorting / numbering
 	set code:

--- a/data/magic-m15-paradox.mse-style/style
+++ b/data/magic-m15-paradox.mse-style/style
@@ -6,7 +6,7 @@ icon: card-sample.png
 installer group: magic/m15 style/normal cards
 position hint: 020
 
-version: 2018-02-09
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -71,6 +71,10 @@ init script:
 	un_png := replace@(match:".png", replace: "")
 	use_vorthos := {styling.vorthos_box}
 
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color}
+
+
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -106,6 +110,10 @@ styling field:
 	name: vorthos box
 	description: Enable the vorthos box
 	initial: no
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: boolean
 	name: color indicator dot
@@ -270,7 +278,7 @@ card style:
 	type:
 		left: { if has_identity() then "52" else "32" }
 		top: { 296 + shrink_type() }
-		width: { (if has_identity() then "290" else "310") - max(22,card_style.rarity.content_width) }
+		width: { (if has_identity() then "290" else "310") - rare_width() }
 		height: { 20  - shrink_type() }
 		alignment: top shrink-overflow
 		z index: 1
@@ -293,28 +301,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-saga.mse-style/style
+++ b/data/magic-m15-saga.mse-style/style
@@ -6,7 +6,7 @@ installer group: magic/m15 style/sagas
 icon: card-sample.png
 position hint: 010
 
-version: 2020-05-10
+version: 2024-01-04
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -230,44 +230,8 @@ init script:
 	add_spacers := { if input == "" and (margin_code == "lv1" or margin_code == "lv2" or margin_code == "lv3") then "​" else input}
 
 	# alternate rarity color
-	alt_rarity := {styling.alt_rarity_color != ""}
-	alt_rarity_color := {
-		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
-		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
-		colons := length(filter_text(string, match:":"))
-		output := split_text(string, match:",|:")
-		splits := split_text(string, match:":")
-		final_num := to_real(splits[length(splits)-2]) or else 0
-		final_border := final_num > 0 and final_num < 1
-		final_num := if not final_border then "0.07" else to_string(final_num);
-		if final_border then (
-			colons := colons - 1;
-			string := replace(string, match:"{final_num}:", replace:"")
-		)
-		if colons == 4
-			then output := split_text(string+final_num+":", match:",|:")
-		if colons == 3
-			then output := split_text(string+splits[2]+final_num+":", match:",|:")
-		else if colons == 2
-			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
-		else if colons == 1
-			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
-		
-		output
-	}
-	alt_symbol := {
-		alt_array := alt_rarity_color()
-		symbol_variation(
-			symbol:set.symbol,
-			border_radius: alt_array.12,
-			fill_type: "linear gradient",
-			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
-			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
-			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
-			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
-			center_x:0.5, center_y:0.5, end_x:1, end_y:1
-		)
-	}
+	alt_rarity := {styling.alt_rarity_color}
+
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -617,7 +581,7 @@ card style:
 	type:
 		left: { if has_identity() then "53" else "33" }
 		top: { 444 + shrink_type() }
-		width: { 309 - max(22,card_style.rarity.content_width) }
+		width: { 309 - rare_width() }
 		height: { 20 - shrink_type() }
 		alignment: top shrink-overflow
 		z index: 2
@@ -640,34 +604,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
-					else if alt_rarity() then alt_symbol()
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-saga.mse-style/style
+++ b/data/magic-m15-saga.mse-style/style
@@ -228,6 +228,46 @@ init script:
 	}
 	###add blank spaces to inner levels so they still are clickable while "empty"
 	add_spacers := { if input == "" and (margin_code == "lv1" or margin_code == "lv2" or margin_code == "lv3") then "​" else input}
+
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color != ""}
+	alt_rarity_color := {
+		string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
+		if match(styling.alt_rarity_color, match:":$") then string := styling.alt_rarity_color
+		colons := length(filter_text(string, match:":"))
+		output := split_text(string, match:",|:")
+		splits := split_text(string, match:":")
+		final_num := to_real(splits[length(splits)-2]) or else 0
+		final_border := final_num > 0 and final_num < 1
+		final_num := if not final_border then "0.07" else to_string(final_num);
+		if final_border then (
+			colons := colons - 1;
+			string := replace(string, match:"{final_num}:", replace:"")
+		)
+		if colons == 4
+			then output := split_text(string+final_num+":", match:",|:")
+		if colons == 3
+			then output := split_text(string+splits[2]+final_num+":", match:",|:")
+		else if colons == 2
+			then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
+		else if colons == 1
+			then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
+		
+		output
+	}
+	alt_symbol := {
+		alt_array := alt_rarity_color()
+		symbol_variation(
+			symbol:set.symbol,
+			border_radius: alt_array.12,
+			fill_type: "linear gradient",
+			fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
+			fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
+			border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
+			border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
+			center_x:0.5, center_y:0.5, end_x:1, end_y:1
+		)
+	}
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -330,6 +370,10 @@ styling field:
 	name: color indicator dot
 	description: Use the color indicator dot
 	initial: no
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: boolean
 	name: remove from autocount
@@ -596,28 +640,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic-m15-split-fusable.mse-style/style
+++ b/data/magic-m15-split-fusable.mse-style/style
@@ -6,7 +6,7 @@ icon: card-sample.png
 installer group: magic/m15 style/split cards/fuse
 position hint: 011
 
-version: 2018-06-01
+version: 2024-01-05
 depends on:
 	package: magic.mse-game
 	version: 2014-06-25
@@ -187,6 +187,10 @@ init script:
 
 	left_font_size := {to_number(pull_comma_array(styling.font_size_cap, end:false, cell:0, default:13))}
 	right_font_size := {to_number(pull_comma_array(styling.font_size_cap, end:false, cell:1, default:left_font_size()))}
+
+	# alternate rarity color
+	alt_rarity := {styling.alt_rarity_color}
+	
 ############################################################## Set info fields
 set info style:
 	symbol:
@@ -244,6 +248,10 @@ styling field:
 	name: holofoil stamped rares
 	description: Use holofoil stamps on rares?
 	initial: yes
+styling field:
+	type: text
+	name: alt rarity color
+	description: Use a custom color for the rarity symbol. Formatted as "R1,G1,B1:R2,G2,B2:...:X:" 1 and 2 are fill color, 3 and 4 border color, X is border thickness. For example, rare is 214,196,94:95,84,40:0,0,0:0,0,0:0.07
 styling field:
 	type: boolean
 	name: grey hybrid name
@@ -514,28 +522,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:
@@ -554,28 +568,34 @@ card style:
 			basic land:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			common:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "c.png"
+					else if use_alt_rarity() then alt_symbol()
 					else if styling.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 					else symbol_variation(symbol: set.symbol, variation: "common")
 			uncommon:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "u.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "uncommon")
 			rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "r.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "rare")
 			mythic rare:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "m.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "mythic rare")
 			special:
 				script:
 					if use_main_rarity() then "/magic-mainframe-extras.mse-include/" + un_png(set.mainframe_rarity_name) + "s.png"
+					else if use_alt_rarity() then alt_symbol()
 					else symbol_variation(symbol: set.symbol, variation: "special")
 			masterpiece:
 				script:

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -1942,6 +1942,116 @@ phy_reminder := {
 	reminder_text
 }
 
+###### Print Fix
+rare_width := {
+	cw := card_style.rarity.content_width
+	cw := if cw > 44 then (if set.print_fix != "" then set.print_fix else 22) else if cw < 22 then 22 else cw
+	if card_style.rarity.width == 0 then 0 else cw
+}
+
+### Customize fonts
+swap_font := {false} ##{styling.apply_custom_fonts}
+split_font := split_text@(match:";")
+pop_font_name := {split_font(input).0 or else ""}
+pop_font_size := {split_font(input).1 or else ""}
+pop_font_color := {split_font(input).2 or else ""}
+pop_font_vertical := {split_font(input).3 or else ""}
+pop_font_italic := {split_font(input).4 or else ""}
+
+swap_font_name := {
+	if swap_font() then (
+		test := pop_font_name(src)
+		if test != "" then font_name := test
+	)
+	
+	font_name
+}@(font_name:"", src:"")
+swap_font_size := {
+	if swap_font() then (
+		test := pop_font_size(src)
+		if test != "" then font_size := test
+	)
+	
+	font_size - shrink_name()
+}@(font_size:16, src:"")
+swap_font_color := {
+	if swap_font() then (
+		test := pop_font_color(src)
+		nums := split_text(test, match:",")
+		test_color := nil
+		
+		if length(nums) >= 4 then test_color := rgba(nums.0, nums.1, nums.2, nums.3) or else nil
+		if test_color == nil and length(nums) >= 3 then test_color := rgb(nums.0, nums.1, nums.2) or else nil
+		if test_color == nil and test != "" then test_color := to_color(test) or else nil
+		if test_color != nil then font_color := test_color
+	) else ""
+	
+	font_color
+}@(font_color:"", src:"")
+swap_font_vertical := {
+	if swap_font() then (
+		test := pop_font_vertical(src)
+		if test != "" then vertical := to_number(test)
+	)
+	
+	vertical
+}@(vertical:0, src:"")
+swap_font_italic := {
+	font_name := "MPlantin-Italic"
+	if swap_font() then (
+		test := pop_font_italic(styling.custom_body_font)
+		test2 := pop_font_name(styling.custom_body_font)
+		if test != "" then font_name := test
+		else if test2 != "" then font_name := ""
+	)
+	
+	font_name
+}@(font_name:"", src:"")
+
+#### Customize rarity symbol
+alt_rarity := {""} ##{styling.alt_rarity_color}
+use_alt_rarity := {alt_rarity() != ""}
+alt_rarity_color := {
+	string := "83,67,53:177,150,131:0,0,0:0,0,0:0.07:"
+	src := alt_rarity()
+	if match(src, match:":$") then string := src
+	colons := length(filter_text(string, match:":"))
+	output := split_text(string, match:",|:")
+	splits := split_text(string, match:":")
+	final_num := to_real(splits[length(splits)-2]) or else 0
+	final_border := final_num > 0 and final_num < 1
+	final_num := if not final_border then "0.07" else to_string(final_num);
+	if final_border then (
+		colons := colons - 1;
+		string := replace(string, match:"{final_num}:", replace:"")
+	)
+	if colons == 4
+		then output := split_text(string+final_num+":", match:",|:")
+	if colons == 3
+		then output := split_text(string+splits[2]+":"+final_num+":", match:",|:")
+	else if colons == 2
+		then output := split_text(string+"0,0,0:0,0,0:"+final_num+":", match:",|:")
+	else if colons == 1
+		then output := split_text(string+splits[0]+":0,0,0:0,0,0:"+final_num+":", match:",|:")
+	
+	output
+}
+alt_symbol := {
+	alt_array := alt_rarity_color()
+	symbol_variation(
+		symbol:set.symbol,
+		border_radius: alt_array.12,
+		fill_type: "linear gradient",
+		fill_color_1: rgb(alt_array.0, alt_array.1, alt_array.2),
+		fill_color_2: rgb(alt_array.3, alt_array.4, alt_array.5),
+		border_color_1: rgb(alt_array.6, alt_array.7, alt_array.8),
+		border_color_2: rgb(alt_array.9, alt_array.10, alt_array.11),
+		center_x:0.5, center_y:0.5, end_x:1, end_y:1
+	)
+}
+
+
+
 # rough type_of script
 # fine for nil, boolean, color, date, string, number, and array
 # map and image are trickier

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -1863,7 +1863,6 @@ saga_ch_placement := {
 }
 
 card_face := {
-	trace(margin_code)
 	front := card[input]
 	back := if card[input+"_2"] or else "" != "" then card[input+"_2"] else card[input]
 	if match(margin_code, match:"(text[2456]|lv[5678])") then back else front


### PR DESCRIPTION
Updates the alternate rarity color script to recognize when the final entry is border width even if its not fully filled in. Updates the description to note border width is a changeable attribute.

Adds alternate rarity script to Adventure, Aftermath, Sagas, and Mainframe DFC. more will be added prior to merge. This will await the Localization PR to merge.