### PR TITLE
Attempt at fixing ticket, tap and untap symbols

### DIFF
--- a/data/magic-genevensis-00-main.mse-style/style
+++ b/data/magic-genevensis-00-main.mse-style/style
@@ -43,10 +43,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-00-main.mse-style/style
+++ b/data/magic-genevensis-00-main.mse-style/style
@@ -43,10 +43,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-01-planeswalker.mse-style/style
+++ b/data/magic-genevensis-01-planeswalker.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-01-planeswalker.mse-style/style
+++ b/data/magic-genevensis-01-planeswalker.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-02-leveler.mse-style/style
+++ b/data/magic-genevensis-02-leveler.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-02-leveler.mse-style/style
+++ b/data/magic-genevensis-02-leveler.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-03-adventure.mse-style/style
+++ b/data/magic-genevensis-03-adventure.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-03-adventure.mse-style/style
+++ b/data/magic-genevensis-03-adventure.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-10-saga.mse-style/style
+++ b/data/magic-genevensis-10-saga.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-10-saga.mse-style/style
+++ b/data/magic-genevensis-10-saga.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-11-class.mse-style/style
+++ b/data/magic-genevensis-11-class.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-11-class.mse-style/style
+++ b/data/magic-genevensis-11-class.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-20-battle.mse-style/style
+++ b/data/magic-genevensis-20-battle.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-20-battle.mse-style/style
+++ b/data/magic-genevensis-20-battle.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-70-token.mse-style/style
+++ b/data/magic-genevensis-70-token.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-70-token.mse-style/style
+++ b/data/magic-genevensis-70-token.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-80-planechase.mse-style/style
+++ b/data/magic-genevensis-80-planechase.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-80-planechase.mse-style/style
+++ b/data/magic-genevensis-80-planechase.mse-style/style
@@ -49,10 +49,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-90-counter.mse-style/style
+++ b/data/magic-genevensis-90-counter.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIE[TK]P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIE[TK]PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIE[TK]PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic-genevensis-90-counter.mse-style/style
+++ b/data/magic-genevensis-90-counter.mse-style/style
@@ -46,10 +46,10 @@ init script:
 	
 	mana_t := { "new" }
 	
-	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WUBRG)")
-	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEcompound(TK)P(WBGUR)")
-	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEcompound(TK)PWUBRG]")
-	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEcompound(TK)PWUBRG/|]") +
+	mana_sort :=		sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WUBRG)")
+	mana_sort_wedge :=	sort_text@(order: "\\?XYZI[0123456789]VLHFDSCAIEP(WBGUR)")
+	mana_unsort :=		sort_text@(order: "[/\\?XYZI0123456789VLHFDSCAIEPWUBRG]")
+	mana_sort_guild :=	sort_text@(order: "[\\?XYZI01234567890VLHFDSCAIEPWUBRG/|]") +
 		replace@(
 			match: "./.|././.|./././.|.[|]",
 			in_context: "(^|[^/])<match>($|[^/])",

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -772,30 +772,31 @@ inserts_values := {
 # Filters for the text box
 # context in which mana symbols are found
 mana_context :=
-	"(?ix)				# case insensitive, ignore whitespace
-	 (^|[[:space:]\"(“'])		# start of a word
-		 (
-			<match>:			# G: something
-		 |  <match>,			# G, tap: something
-		 |  or[ ]<match>		# Add X, Y, or Z.
-		 |  <match>[ ]to[ ]your		# Add X, Y, or Z to your mana pool.
-		 |  you[ ]get[ ]<match>		# You get E, you get TK
-		 |  <match>[ ]was[ ]spent	# if G was spent to cast
-		 |  <match>[ ]can[ ]be[ ]paid
-		 |  (pays?|additional|costs?|the|adds?|pay(ed)?[ ](with|using))	# pay X. creatures cost 1 less. pay an additional G.
-			([ ]either)?			 # pay either X or Y
-			([ ](<sym[^>]*>)?[-+=]?[VLHSCETKQ\\?XYZIEWUBRG0-9/|]+(</sym[^>]*>)?,)* # pay X, Y or Z
-			([ ](<sym[^>]*>)?[-+=]?[VLHSCETKQ\\?XYZIEWUBRG0-9/|]+(</sym[^>]*>)?[ ](and|or|and/or))* # pay X or Y
-			[ ]<match>
-			([,.)\"”]|$				# (end of word)
-			|[ ][^ .,]*$			# still typing...
-			|[ ]( or | and | in | less | more | to ) # or next word is ...
-		 )
-	 )
-	 |  <param-mana><match></param-mana>		# keyword argument that is declared as mana
-	 |  <param-cost>[ ]*<match></param-cost>	# keyword argument that is declared as cost
-	 |  <param-cost><match>,			# keyword argument that is declared as cost
-	 ";
+	"(?ix)                                                      # case insensitive, ignore whitespace
+	 (^|[[:space:]\"(“'])                                       # start of a word
+		(
+				<match>:                                        # G: something
+			|	<match>,                                        # G, tap: something
+			|	or[ ]<match>                                    # Add X, Y, or Z.
+			|	<match>[ ]to[ ]your                             # Add X, Y, or Z to your mana pool.
+			|	you[ ]get[ ]<match>                             # You get E, you get TK
+			|	<match>[ ]was[ ]spent                           # if G was spent to cast
+			|	<match>[ ]can[ ]be[ ]paid
+			|	(pays?|additional|costs?|the|adds?|pay(ed)?[ ](with|using)) # pay X. creatures cost 1 less. pay an additional G.
+				([ ]either)?                                                                            # pay either X or Y
+				([ ](<sym[^>]*>)?[-+=]?[VLHSCETKQ\\?XYZIEWUBRG0-9/|]+(</sym[^>]*>)?,)*                  # pay X, Y or Z
+				([ ](<sym[^>]*>)?[-+=]?[VLHSCETKQ\\?XYZIEWUBRG0-9/|]+(</sym[^>]*>)?[ ](and|or|and/or))* # pay X or Y
+				[ ]<match>
+				(
+						[,.)\"”]|$                              # (end of word)
+					|	[ ][^ .,]*$                             # still typing...
+					|	[ ]( or | and | in | less | more | to ) # or next word is ...
+				)
+		)
+	 |  <param-mana><match></param-mana>                        # keyword argument that is declared as mana
+	 |  <param-cost>[ ]*<match></param-cost>                    # keyword argument that is declared as cost
+	 |  <param-cost><match>,                                    # keyword argument that is declared as cost
+	";
 mana_un_context := "(converted mana costs? <match>|<match> life)"
 
 # truncates the name of legends

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -797,7 +797,7 @@ mana_context :=
 	 |  <param-cost>[ ]*<match></param-cost>                    # keyword argument that is declared as cost
 	 |  <param-cost><match>,                                    # keyword argument that is declared as cost
 	";
-mana_un_context := "(converted mana costs? <match>|<match> life)"
+mana_un_context := "(mana values? <match>|converted mana costs? <match>|<match> life)"
 
 # truncates the name of legends
 legend_filter := replace@(match:"(, | of | the | \"| “).*", replace: "" )

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -11,12 +11,12 @@ version_date := {"2023-02-21"}
 ############################################################## Sorting mana symbols
 
 # correctly sort a mana symbol (no guild mana)
-mana_sort       := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIEcompound(TK)(WUBRG)") 
+mana_sort       := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIE(WUBRG)") 
 # correctly sort wedge mana
-mana_sort_wedge := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIEcompound(TK)(WBGUR)")
-mana_unsort := sort_text@(order:"[/\\?XYZI0123456789VLHSCAIEcompound(TK)WUBRG]")
+mana_sort_wedge := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIE(WBGUR)")
+mana_unsort := sort_text@(order:"[/\\?XYZI0123456789VLHSCAIEWUBRG]")
 # correctly sort guild mana
-mana_sort_guild := sort_text@(order: "[\\?XYZI01234567890VLHSFCAIEcompound(TK)WUBRG/|]") +
+mana_sort_guild := sort_text@(order: "[\\?XYZI01234567890VLHSFCAIEWUBRG/|]") +
 		replace@(
 			# No lookbehind :(
 			#match: "(?<!/)(./.|././.|./././.|.[|])(?!/)",
@@ -55,14 +55,16 @@ mana_filter := to_upper + {
 }
 # Like mana filter, only also allow tap symbols:
 tap_reduction :=
-	replace@(match:"(TK)+", replace:"")+
 	replace@(match:"T+", replace:"T")+
 	replace@(match:"Q+", replace:"Q")
-tap_filter := filter_text@(match: "[TKQ]")
+ticket_filter := 
+ticket_isolate := filter_text@(match:"(TK)+")
+tap_filter := replace@(match:"(TK)+", replace:"")+
+	sort_text@(order: "<TQ>")
 mana_filter_t := replace@(               # Remove [] used for forcing mana symbols
 			match: "[\\[\\]]",
 			replace: ""
-		) + { tap_reduction(tap_filter(in_context:""), in_context:"") + mana_filter() }
+		) + { tap_reduction(tap_filter()) + mana_filter() }
 
 ############################################################## Determine card color
 
@@ -777,7 +779,8 @@ mana_context :=
 		 |  <match>,			# G, tap: something
 		 |  or[ ]<match>		# Add X, Y, or Z.
 		 |  <match>[ ]to[ ]your		# Add X, Y, or Z to your mana pool.
-		 |  <match>[ ]was[ ]spent		# if G was spent to cast
+		 |  you[ ]get[ ]<match>		# You get E, you get TK
+		 |  <match>[ ]was[ ]spent	# if G was spent to cast
 		 |  <match>[ ]can[ ]be[ ]paid
 		 |  (pays?|additional|costs?|the|adds?|pay(ed)?[ ](with|using))	# pay X. creatures cost 1 less. pay an additional G.
 			([ ]either)?			 # pay either X or Y
@@ -1011,7 +1014,7 @@ text_filter :=
 	} +
 	# step 4 : explict non mana symbols
 	replace@(
-		match: "\\][-+=]?[VLHSCETKQ\\?XYZIWUBRG0-9/|]+\\[",
+		match: "\\][-+=]?[VLHSCETQ\\?XYZIWUBRG0-9/|]+\\[",
 		replace: {"<nosym>" + mana_filter_t() + "</nosym>"} ) +
 	# step 5 : add mana & tap symbols
 	replace@(
@@ -1019,17 +1022,21 @@ text_filter :=
 		in_context: mana_context,
 		replace: {"<sym-auto>" + _1 + "</sym-auto>"} ) +
 	replace@(
-		match: "\\b[VLHSCETKQ\\?XYZIWUBRG0-9/|]+\\b",
+		match: "\\b((TK)+)(T)?\\b",
+		in_context: mana_context,
+		replace: {"<sym-auto>" + _1 + "</sym-auto>" + _3}) +
+	replace@(
+		match: "\\b[VLHSCETQ\\?XYZIWUBRG0-9/|]+\\b",
 		in_context: mana_context,
 		replace: {"<sym-auto>" + mana_filter_t() + "</sym-auto>"} ) +
 	# step 5b : remove false positive mana & tap symbols
 	replace@(
-		match: "<sym-auto>([VLHSCETKQ\\?XYZIWUBRG0-9/|]+)</sym-auto>",
+		match: "<sym-auto>([VLHSCETQ\\?XYZIWUBRG0-9/|]+)</sym-auto>",
 		in_context: mana_un_context,
 		replace: "\\1" ) +
 	# step 5c : add explicit mana symbols
 	replace@(
-		match: "\\[[-+=]?[VLHSCETKQE\\?XYZIWUBRG0-9/|]+\\]",
+		match: "\\[[-+=]?[VLHSCETQE\\?XYZIWUBRG0-9/|]+\\]",
 		replace: {"<sym>" + mana_filter_t() + "</sym>"} ) +
 	# step 6 : curly quotes
 	{if set.curly_quotes then curly_quotes(input) else input} +

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -11,12 +11,12 @@ version_date := {"2023-02-21"}
 ############################################################## Sorting mana symbols
 
 # correctly sort a mana symbol (no guild mana)
-mana_sort       := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIE[TK](WUBRG)") 
+mana_sort       := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIEcompound(TK)(WUBRG)") 
 # correctly sort wedge mana
-mana_sort_wedge := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIE[TK](WBGUR)")
-mana_unsort := sort_text@(order:"[/\\?XYZI0123456789VLHSCAIETKWUBRG]")
+mana_sort_wedge := sort_text@(order: "\\?XYZI[0123456789]VLHSFCAIEcompound(TK)(WBGUR)")
+mana_unsort := sort_text@(order:"[/\\?XYZI0123456789VLHSCAIEcompound(TK)WUBRG]")
 # correctly sort guild mana
-mana_sort_guild := sort_text@(order: "[\\?XYZI01234567890VLHSFCAIETKWUBRG/|]") +
+mana_sort_guild := sort_text@(order: "[\\?XYZI01234567890VLHSFCAIEcompound(TK)WUBRG/|]") +
 		replace@(
 			# No lookbehind :(
 			#match: "(?<!/)(./.|././.|./././.|.[|])(?!/)",
@@ -62,7 +62,7 @@ tap_filter := filter_text@(match: "[TKQ]")
 mana_filter_t := replace@(               # Remove [] used for forcing mana symbols
 			match: "[\\[\\]]",
 			replace: ""
-		) + { tap_reduction(tap_filter()) + mana_filter() }
+		) + { tap_reduction(tap_filter(in_context:""), in_context:"") + mana_filter() }
 
 ############################################################## Determine card color
 


### PR DESCRIPTION
Not sure I understand the situation correctly, but here is what I gather:

Having added `[TK]` to the `mana_sort` function allows it to return `T`, which in turn allows the `mana_filter` function to return `T` as well. Changing `[TK]` to `compound(TK)` seems to work (but TK can no longer be written manually, it must be pasted wholesale or inserted via the insert symbol menu, since `mana_sort` won't allow T or K individually).

The `mana_filter_t` function is implicitly passed an `in_context: mana_context` argument when called within the `text_filter` function. This was preventing it from returning a T or Q. I believe in all cases it's correct to override that to the empty string.

So `tap_reduction(tap_filter())` was not letting through T when it should, and `mana_filter()` was letting T through when it shouldn't. These two wrongs together made a right where it allowed `T:`, but it did not work in the case of `Q:` since "TK" only contains the letter T and not the letter Q.