### PR TITLE
MKM + PIP type/keyword updates

### DIFF
--- a/data/magic.mse-game/keywords
+++ b/data/magic.mse-game/keywords
@@ -1795,9 +1795,36 @@ keyword:
 	match: finality counter
 	mode: core
 	reminder: If a creature with a finality counter would die, exile it instead.
+# Murders at Karlov Manor
+keyword:
+	keyword: Cloak
+	match: cloak
+	mode: action
+	reminder: To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward [2]. Turn it face up any time for its mana cost if it's a creature card.
+keyword:
+	keyword: Collect evidence
+	match: collect evidence <atom-param>number</atom-param>
+	mode: action
+	reminder: Exile cards with total mana value {param1} or greater from your graveyard.
+keyword:
+	keyword: Disguise
+	match: Disguise <atom-param>cost</atom-param>
+	mode: expert
+	reminder: You may cast this card face down for [3] as a 2/2 creature with ward [2]. Turn it face up any time for its disguise cost.
+keyword:
+	keyword: Suspect
+	match: suspect
+	mode: action
+	reminder: A suspected creature has menace and can’t block.
 # Fallout
 keyword:
 	keyword: Junk token
 	match: Junk toke<atom-param>*s</atom-param>
 	mode: expert
 	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "T, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery."
+# Assassin's Creed
+keyword:
+	keyword: Freerunning
+	match: Freerunning <atom-param>cost</atom-param>
+	mode: expert
+	reminder: You may cast this spell for {param1} if you've dealt combat damage to a player with an Assassin or your commander this turn.

--- a/data/magic.mse-game/language_map
+++ b/data/magic.mse-game/language_map
@@ -1226,7 +1226,7 @@ languages := [
 			+ "Squid,"
 			+ "Squirrel,"
 			+ "Starfish,"
-			+ "Surrakar",
+			+ "Surrakar,"
 			+ "Synth",
 
 			  "Tentacle,"
@@ -4147,8 +4147,8 @@ languages := [
 			+ "暗殺者",
 
 			  "海賊,"
-			+ "科学者",
-			+ "科学家"
+			+ "科学者,"
+			+ "科学家",
 
 			  "侍,"
 			+ "邪術師",

--- a/data/magic.mse-game/language_map
+++ b/data/magic.mse-game/language_map
@@ -186,6 +186,7 @@ languages := [
 			+ "Wüste",
 		word_list_enchantment:
 			  "Aura,"
+			+ "Fall,"
 			+ "Fluch,"
 			+ "Hintergrund,"
 			+ "Kartusche,"
@@ -1648,6 +1649,7 @@ languages := [
 			  "Altar,"
 			+ "Aura,"
 			+ "Cartucho,"
+			+ "Caso,"
 			+ "Clase,"
 			+ "Fragmento,"
 			+ "Maldición,"
@@ -2350,7 +2352,8 @@ languages := [
 			+ "sphère,"
 			+ "tour",
 		word_list_enchantment:
-			  "aura,"
+			  "affaire,"
+			+ "aura,"
 			+ "cartouche,"
 			+ "classe,"
 			+ "éclat,"
@@ -3063,6 +3066,7 @@ languages := [
 			+ "Aura,"
 			+ "Background,"
 			+ "Cartiglio,"
+			+ "Caso,"
 			+ "Classe,"
 			+ "Frammento,"
 			+ "Runa,"
@@ -5216,6 +5220,7 @@ languages := [
 			  "Antecedente,"
 			+ "Aura,"
 			+ "Cártula,"
+			+ "Caso,"
 			+ "Classe,"
 			+ "Fragmento,"
 			+ "Maldição,"

--- a/data/magic.mse-game/language_map
+++ b/data/magic.mse-game/language_map
@@ -1773,11 +1773,12 @@ languages := [
 			+ "Caribú,"
 			+ "Cefálido,"
 			+ "Centauro,"
-			+ "Chacal,"
-			+ "Cíclope,"
-			+ "Cieno",
+			+ "Chacal,",
 
-			  "Cocatriz,"
+			  "Cíclope,"
+			+ "Cieno",
+			+ "Científico,"
+			+ "Cocatriz,"
 			+ "Cocodrilo,"
 			+ "Conejo,"
 			+ "Constructo,"
@@ -3448,6 +3449,7 @@ languages := [
 			  "Samurai,"
 			+ "Scheletro,"
 			+ "Sciamano,"
+			+ "Scienziato,"
 			+ "Servitore,"
 			+ "Servo,"
 			+ "Soldato,"
@@ -4137,6 +4139,7 @@ languages := [
 
 			  "海賊,"
 			+ "科学者",
+			+ "科学家"
 
 			  "侍,"
 			+ "邪術師",
@@ -5561,6 +5564,7 @@ languages := [
 
 			  "Cavaleiro,"
 			+ "Cidadão,"
+			+ "Cientista,"
 			+ "Clérigo,"
 			+ "Conselheiro,"
 			+ "Couraçado,"

--- a/data/magic.mse-game/language_map
+++ b/data/magic.mse-game/language_map
@@ -877,6 +877,7 @@ languages := [
 		word_list_artifact:
 			  "Attraction,"
 			+ "Blood,"
+			+ "Bobblehead,"
 			+ "Clue,"
 			+ "Contraption,"
 			+ "Equipment,"
@@ -884,6 +885,7 @@ languages := [
 			+ "Fortification,"
 			+ "Gold,"
 			+ "Incubator,"
+			+ "Junk,"
 			+ "Map,"
 			+ "Powerstone,"
 			+ "Treasure,"
@@ -907,6 +909,7 @@ languages := [
 			  "Aura,"
 			+ "Background,"
 			+ "Cartouche,"
+			+ "Case,"
 			+ "Class,"
 			+ "Curse,"
 			+ "Role,"
@@ -1205,6 +1208,7 @@ languages := [
 			+ "Skeleton,"
 			+ "Slith,"
 			+ "Sliver,"
+			+ "Sloth,"
 			+ "Slug,"
 			+ "Snail,"
 			+ "Snake",
@@ -1222,6 +1226,7 @@ languages := [
 			+ "Squirrel,"
 			+ "Starfish,"
 			+ "Surrakar",
+			+ "Synth",
 
 			  "Tentacle,"
 			+ "Tetravite,"
@@ -1773,12 +1778,11 @@ languages := [
 			+ "Caribú,"
 			+ "Cefálido,"
 			+ "Centauro,"
-			+ "Chacal,",
-
-			  "Cíclope,"
+			+ "Chacal,"
+			+ "Cíclope,"
 			+ "Cieno",
-			+ "Científico,"
-			+ "Cocatriz,"
+			
+			  "Cocatriz,"
 			+ "Cocodrilo,"
 			+ "Conejo,"
 			+ "Constructo,"
@@ -1998,6 +2002,7 @@ languages := [
 			  "Caballero,"
 			+ "Cambiahechizos,"
 			+ "Chamán,"
+			+ "Científico,"
 			+ "Ciudadano,"
 			+ "Clérigo,"
 			+ "Cobarde,"
@@ -2009,11 +2014,11 @@ languages := [
 			+ "Engendro,"
 			+ "Espíritu,"
 			+ "Esqueleto,"
-			+ "Explorador,"
-			+ "Guardabosque,"
-			+ "Guerrero",
+			+ "Explorador",
 
-			  "Hechicero,"
+			  "Guardabosque,"
+			+ "Guerrero,"
+			+ "Hechicero,"
 			+ "Horror,"
 			+ "Huevo,"
 			+ "Leviatán,"

--- a/data/magic.mse-game/word_lists
+++ b/data/magic.mse-game/word_lists
@@ -1130,11 +1130,11 @@ word list:
 		word:
 			name: C
 			word:
-				name: Ca-Ch
+				name: Ca-Ci
 				word:
 					script: lang_setting("word_lists_race").2
 			word:
-				name: Ci-Cz
+				name: Co-Cz
 				word:
 					script: lang_setting("word_lists_race").3
 		word:
@@ -1241,11 +1241,11 @@ word list:
 			word:
 				script: lang_setting("word_lists_class").0
 		word:
-			name: C-G
+			name: C-F
 			word:
 				script: lang_setting("word_lists_class").1
 		word:
-			name: H-N
+			name: G-N
 			word:
 				script: lang_setting("word_lists_class").2
 		word:

--- a/data/magic.mse-game/word_lists
+++ b/data/magic.mse-game/word_lists
@@ -1130,11 +1130,11 @@ word list:
 		word:
 			name: C
 			word:
-				name: Ca-Ci
+				name: Ca-Ch
 				word:
 					script: lang_setting("word_lists_race").2
 			word:
-				name: Co-Cz
+				name: Ci-Cz
 				word:
 					script: lang_setting("word_lists_race").3
 		word:


### PR DESCRIPTION
update the type lists and keyword files for MKM and PIP

TODO, anyone
copy over the translated MKM keywords
wait for the translated PIP types

TODO, cajun
switch the gojuon directions for Japanese
rebuild Japanese and Chinese with types localizer