### PR TITLE
Unique Card ID

### DIFF
--- a/data/magic.mse-game/card_fields
+++ b/data/magic.mse-game/card_fields
@@ -2981,3 +2981,26 @@ card field:
 	card list alignment: right
 	card list width: 50
 	script: custom_index()
+
+card field:
+	type: text
+	name: id compulse save
+	description: Absolute voodoo shit that seems to force MSE to save the card.id field even when in its default state.
+	save value: true
+	show statistics: false
+	card list allow: false
+	script: forward_editor(prefix: position(of: card, in: set), field: card.id)
+
+card field:
+	type: text
+	name: id
+	description: A unique ID for the card. No two cards in the set will have the same ID. Adding or deleting a card to the set will not change another card's ID.
+	show statistics: false
+	save value: true
+	editable: false
+	card list visible: true
+	card list name: ID
+	card list column: 9998
+	card list alignment: right
+	card list width: 60
+	script: card_id_script()

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -4652,3 +4652,25 @@ skeleton_info := {
 	+"skeleton_wedge_uncommons: " + skeleton_wedge_uncommons + "\n"
 	+"skeleton_wedge_rares: " + skeleton_wedge_rares)
 }
+
+############################################################## Card ID
+#### DO NOT CHANGE OR OVERWRITE THIS METHOD
+card_id_script :=
+{
+	id :=				to_int(value)
+	max_id :=			0
+	must_change_id :=	id == 0
+	index :=			position(of: card, in: set.cards)
+	max_index :=		length(set.cards)-1
+	for i from 0 to max_index do
+	(
+		other_id := to_int(set.cards[i].id)
+		if max_id < other_id then max_id := other_id
+		if		i < index
+			and	not must_change_id
+			and	other_id == id
+		then must_change_id := true
+		""
+	)
+	if must_change_id then max_id + 1 else id
+}

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -4657,6 +4657,12 @@ skeleton_info := {
 #### DO NOT CHANGE OR OVERWRITE THIS METHOD
 card_id_script :=
 {
+	#### We take advantage of the fact that set.cards always keeps the same ordering, even through saves and loads.
+	#### In particular, cards always appear in the chronological order in which they were added to the set.
+	#### Each card will look at all the preceding cards to see if one of them has the same ID. If so it will change its ID.
+	#### This means that cards added before it will have priority, and so will never change their ID, even as we add more cards in the set.
+	#### This in turn ensures a card only changes its ID when it is added to the set,
+	#### and afterwards always keeps the same ID throughout it's lifetime in the set. (Hopefully)
 	id :=				to_int(value)
 	max_id :=			0
 	must_change_id :=	id == 0


### PR DESCRIPTION
Attempt at creating a unique card id field.

The field should have the following properties:
 - It's value is always an integer.
 - No two cards in a set can ever have the same value.
 - Once a card has been added to the set, its value can never change.

The id can probably be made more unique by integrating `card.time_created`, but it's unclear if that would be useful.