### PR TITLE
Updated reminder text, added living metal

### DIFF
--- a/data/magic.mse-game/keywords
+++ b/data/magic.mse-game/keywords
@@ -1563,7 +1563,7 @@ keyword:
 	keyword: Casualty
 	match: Casualty <atom-param>number</atom-param>
 	mode: expert
-	reminder: As you cast this spell, you may sacrifice a creature with power {param1}{if param1 == "X" then "." else " or greater."} When you do, copy this spell{ if is_targeted() then " and you may choose a new target for the copy." }
+	reminder: As you cast this spell, you may sacrifice a creature with power {param1}{if param1 == "X" then "." else " or greater."} When you do, copy this spell{ if is_targeted() then " and you may choose a new target for the copy" }.
 keyword:
 	keyword: Connive
 	match: connive


### PR DESCRIPTION
Updated reminder texts to their current Oracle reminder texts (many changes from "enters the battlefield" to "enters", various other reminder text updates)

Added the mechanic "living metal" (from the Transformers set)

Changed the mechanic "stare down" from expert to action

Fixed typo on "fathomless descent"