### PR TITLE
add system for (To keyword, ...) reminder text

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,8 @@ OTHER UPDATES
 • Added support for Custom Watermarks up to a maximum size of 1024x1024. Watermarks that aren't 500x500 will still need to include their height and width.
 • Split the "blend with colors" watermark option into one that applies to custom watermarks and one that applies to default watermarks.
 • Reorganized the Set tab into something hopefully easier to navigate.
+• Added the keyword utility handle_action_rt(to:"name", "Action"). This can be used to add "To {name}," before the reminder text when it isn't right next to the keyword, such as handle_action_rt(to:"forage", "Exile"). capitalization matters here.
+• Added the keyword utility handle_merged_rt("Normal", moved:"Alternate"). This can be used to add clarifying text when reminder text is merged, like in [card]Cache Grab[/card]. Unlike the previous, this only changes during reminder text merges, not any distance from the keyword.
 • Added the up and down triangles as mainframe transform options.
 • Added support for dungeons with 8 levels.
 • Added option to remove backface rarity symbol to Mainframe DFC.

--- a/data/magic.mse-game/keywords
+++ b/data/magic.mse-game/keywords
@@ -872,7 +872,7 @@ keyword:
 	keyword: Populate
 	match: populate
 	mode: action
-	reminder: {handle_action_rt(to:"Populate", "Create")} a token that's a copy of a creature token you control.
+	reminder: {handle_action_rt(to:"populate", "Create")} a token that's a copy of a creature token you control.
 # Gatecrash
 keyword:
 	keyword: Extort

--- a/data/magic.mse-game/keywords
+++ b/data/magic.mse-game/keywords
@@ -382,7 +382,7 @@ keyword:
 	reminder:
 		{ handle_action_rt(to:"scry {param1}", "Look")} at the top {
 		 if param1.value=="1" then "card of your library. You may put that card on the bottom of your library."
-		 else "{english_number(param1)} cards of your library, then put any number of them on the bottom of your library and the rest on top in any order."
+		 else "{english_number(param1)} cards of your library, then put any number of them on the bottom and the rest on top in any order."
 		}
 keyword:
 	keyword: Sunburst
@@ -780,7 +780,7 @@ keyword:
 	keyword: Proliferate
 	match: Proliferate
 	mode: action
-	reminder: {handle_action_rt(to:"proliferate", "Choose")} any number of permanents and/or players with counters on them, then give each another counter of each kind already there.
+	reminder: {handle_action_rt(to:"proliferate", "Choose")} any number of permanents and/or players, then give each another counter of each kind already there.
 keyword:
 	keyword: Metalcraft
 	match: Metalcraft
@@ -1028,7 +1028,7 @@ keyword:
 	keyword: Manifest
 	match: manifest
 	mode: action
-	reminder: {handle_action_rt(to:"manifest a card", "put")} it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.
+	reminder: {handle_action_rt(to:"manifest a card", "Put")} it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.
 # Dragons of Tarkir
 keyword:
 	keyword: Exploit
@@ -1109,7 +1109,7 @@ keyword:
 	keyword: Investigate
 	match: Investigate
 	mode: action
-	reminder: {handle_action_rt(to:"investigate", "Create")} a colorless Clue artifact token with "<sym>2</sym>, Sacrifice this artifact: Draw a card."
+	reminder: {handle_action_rt(to:"investigate", "Create")} a Clue token. It's an artifact with "<sym>2</sym>, Sacrifice this artifact: Draw a card."
 keyword:
 	keyword: Skulk
 	match: Skulk
@@ -1238,7 +1238,7 @@ keyword:
 	keyword: Explore
 	match: explores
 	mode: action
-	reminder: {handle_action_rt(to:"explore", "exile")} the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on {this_or_that("creature")}, then put the card back or put it into your graveyard.
+	reminder: {handle_action_rt(to:"explore", "Reveal")} the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on {this_or_that("creature")}, then put the card back or put it into your graveyard.
 #Unstable
 keyword:
 	keyword: Assemble a Contraption
@@ -1344,7 +1344,7 @@ keyword:
 	mode: action
 	reminder:
 		{handle_action_rt(to:"surveil {param1}", "Look")} at the top {
-		 if param1.value=="1" then "card of your library. You may put that card into your graveyard."
+		 if param1.value=="1" then "card of your library. You may put it into your graveyard."
 		 else "{english_number(param1)} cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order."
 		}
 keyword:
@@ -1383,7 +1383,7 @@ keyword:
 	keyword: Amass
 	match: Amass <atom-param>name</atom-param> <atom-param>number</atom-param>
 	mode: action
-	reminder: {handle_action_rt(to:"amass {param1} {param2}", "Create")} {english_number_a(param2)} +1/+1 counter(s) on an Army you control. It's also a {if param1.value == "Zombies" then "Zombie" else english_singular(param1)}. If you don't control one, create a 0/0 black {if param1.value == "Zombies" then "Zombie" else english_singular(param1)} Army creature token first.
+	reminder: {handle_action_rt(to:"amass {param1} {param2}", "Create")} {english_number_a(param2)} +1/+1 counter(s) on an Army you control. It's also a {if param1.value == "Zombies" then "Zombie" else english_singular(param1)}. If you don't control an Army, create a 0/0 black {if param1.value == "Zombies" then "Zombie" else english_singular(param1)} Army creature token first.
 #Throne of Eldraine
 keyword:
 	keyword: Adamant

--- a/data/magic.mse-game/keywords
+++ b/data/magic.mse-game/keywords
@@ -380,9 +380,9 @@ keyword:
 	match: Scry <atom-param>number</atom-param>
 	mode: core
 	reminder:
-		To scry {param1}, look at the top {
-		 if param1.value=="1" then "card of your library. You may put that card on the bottom."
-		 else "{english_number(param1)} cards of your library, then put any number of them on the bottom and the rest on top in any order."
+		{ handle_action_rt(to:"scry {param1}", "Look")} at the top {
+		 if param1.value=="1" then "card of your library. You may put that card on the bottom of your library."
+		 else "{english_number(param1)} cards of your library, then put any number of them on the bottom of your library and the rest on top in any order."
 		}
 keyword:
 	keyword: Sunburst
@@ -580,8 +580,8 @@ keyword:
 	match: Fateseal <atom-param>number</atom-param>
 	mode: action
 	reminder:
-		To fateseal {param1}, look at the top {
-		 if param1.value=="1" then "card of an opponent’s library, then you may put that card on the bottom of that player’s library."
+		{handle_action_rt(to:"fateseal "+param1, "Look")} at the top {
+		 if param1.value=="1" then "card of an opponent’s library, then you may put it on the bottom of that player’s library."
 		 else "{english_number(param1)} cards of an opponent’s library, then put any number of them on the bottom of that player’s library and the rest on top in any order."
 		}
 keyword:
@@ -780,7 +780,7 @@ keyword:
 	keyword: Proliferate
 	match: Proliferate
 	mode: action
-	reminder: Choose any number of permanents and/or players, then give each another counter of each kind already there.
+	reminder: {handle_action_rt(to:"proliferate", "Choose")} any number of permanents and/or players with counters on them, then give each another counter of each kind already there.
 keyword:
 	keyword: Metalcraft
 	match: Metalcraft
@@ -872,7 +872,7 @@ keyword:
 	keyword: Populate
 	match: populate
 	mode: action
-	reminder: Create a token that's a copy of a creature token you control.
+	reminder: {handle_action_rt(to:"Populate", "Create")} a token that's a copy of a creature token you control.
 # Gatecrash
 keyword:
 	keyword: Extort
@@ -1018,7 +1018,7 @@ keyword:
 	keyword: Bolster
 	match: bolster <atom-param>number</atom-param>
 	mode: action
-	reminder: Choose a creature with the least toughness among creatures you control and put {english_number_a(param1)} +1/+1 counter(s) on it.
+	reminder: {handle_action_rt(to:"bolster {param1}", "Choose")} a creature with the least toughness among creatures you control and put {english_number_a(param1)} +1/+1 counter(s) on it.
 keyword:
 	keyword: Dash
 	match: Dash <atom-param>cost</atom-param>
@@ -1028,7 +1028,7 @@ keyword:
 	keyword: Manifest
 	match: manifest
 	mode: action
-	reminder: To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.
+	reminder: {handle_action_rt(to:"manifest a card", "put")} it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.
 # Dragons of Tarkir
 keyword:
 	keyword: Exploit
@@ -1103,13 +1103,13 @@ keyword:
 	keyword: Support
 	match: Support <atom-param>number</atom-param>
 	mode: action
-	reminder: Put a +1/+1 counter on {if param1.value!=1 then "each of "}up to {english_number(param1)}{if has_pt() then " other"} target creature(s).
+	reminder: {handle_action_rt(to:"support {param1}", "Put")} a +1/+1 counter on {if param1.value!=1 then "each of "}up to {english_number(param1)}{if has_pt() then " other"} target creature(s).
 # Shadows over Innistrad
 keyword:
 	keyword: Investigate
 	match: Investigate
 	mode: action
-	reminder: Create a Clue token. It's an artifact with "<sym>2</sym>, Sacrifice this artifact: Draw a card."
+	reminder: {handle_action_rt(to:"investigate", "Create")} a colorless Clue artifact token with "<sym>2</sym>, Sacrifice this artifact: Draw a card."
 keyword:
 	keyword: Skulk
 	match: Skulk
@@ -1238,7 +1238,7 @@ keyword:
 	keyword: Explore
 	match: explores
 	mode: action
-	reminder: Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on {this_or_that("creature")}, then put the card back or put it into your graveyard.
+	reminder: {handle_action_rt(to:"explore", "exile")} the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on {this_or_that("creature")}, then put the card back or put it into your graveyard.
 #Unstable
 keyword:
 	keyword: Assemble a Contraption
@@ -1326,7 +1326,7 @@ keyword:
 	keyword: Treasure token
 	match: Treasure toke<atom-param>*s</atom-param>
 	mode: core
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "T, Sacrifice this artifact: Add one mana of any color."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Treasure token is an artifact")} with "T, Sacrifice this artifact: Add one mana of any color."
 #Guilds of Ravnica
 keyword:
 	keyword: Jump-start
@@ -1343,8 +1343,8 @@ keyword:
 	match: Surveil <atom-param>number</atom-param>
 	mode: action
 	reminder:
-		Look at the top {
-		 if param1.value=="1" then "card of your library. You may put it into your graveyard."
+		{handle_action_rt(to:"surveil {param1}", "Look")} at the top {
+		 if param1.value=="1" then "card of your library. You may put that card into your graveyard."
 		 else "{english_number(param1)} cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order."
 		}
 keyword:
@@ -1383,7 +1383,7 @@ keyword:
 	keyword: Amass
 	match: Amass <atom-param>name</atom-param> <atom-param>number</atom-param>
 	mode: action
-	reminder: Put {english_number_a(param2)} +1/+1 counter(s) on an Army you control. It's also a {if param1.value == "Zombies" then "Zombie" else english_singular(param1)}. If you don't control an Army, create a 0/0 black {if param1.value == "Zombies" then "Zombie" else english_singular(param1)} Army creature token first.
+	reminder: {handle_action_rt(to:"amass {param1} {param2}", "Create")} {english_number_a(param2)} +1/+1 counter(s) on an Army you control. It's also a {if param1.value == "Zombies" then "Zombie" else english_singular(param1)}. If you don't control one, create a 0/0 black {if param1.value == "Zombies" then "Zombie" else english_singular(param1)} Army creature token first.
 #Throne of Eldraine
 keyword:
 	keyword: Adamant
@@ -1394,7 +1394,7 @@ keyword:
 	keyword: Food token
 	match: Food toke<atom-param>*s</atom-param>
 	mode: core
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "2, T, Sacrifice this artifact: You gain 3 life."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Food token is an artifact")} with "2, T, Sacrifice this artifact: You gain 3 life."
 #Theros Beyond Death
 keyword:
 	keyword: Escape
@@ -1405,7 +1405,7 @@ keyword:
 	keyword: Gold token
 	match: Gold toke<atom-param>*s</atom-param>
 	mode: core
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "Sacrifice this artifact: Add one mana of any color."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Gold token is an artifact")} with "Sacrifice this artifact: Add one mana of any color."
 #Ikoria: Lair of Behemoths
 keyword:
 	keyword: Mutate
@@ -1420,9 +1420,9 @@ keyword:
 #Magic 2021
 keyword:
 	keyword: Mill
-	match: <atom-param>mill</atom-param> <atom-param>one_word</atom-param>
+	match: <atom-param>mill</atom-param> <atom-param>one_word</atom-param> car<atom-param>*s</atom-param>
 	mode: core
-	reminder: {if param1.value == "mills" then "They put" else "Put"} the top {if param2.value == "a" then "" else param2 + " "}{if param2.value == "a" then "card" else "cards"} of {if param1.value == "mills" then "their library into their" else "your library into your"} graveyard.
+	reminder: { if param1.value == "mills" then handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "They") + " put the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of their library into their graveyard." else handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "Put") + " the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of your library into your graveyard." }
 keyword:
 	keyword: phases out
 	match: phases out
@@ -1445,7 +1445,7 @@ keyword:
 	keyword: Shard token
 	match: Shard toke<atom-param>*s</atom-param>
 	mode: core
-	reminder: {if param1.value == "ns" then "They’re enchantments" else "It’s an enchantment"} with "2, Sacrifice this enchantment: Scry ]1[, then draw a card."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re enchantments" else "It’s an enchantment", moved:"A Shard token is an enchantment")} with "2, Sacrifice this enchantment: Scry ]1[, then draw a card."
 keyword:
 	keyword: Boast
 	match: Boast
@@ -1461,7 +1461,7 @@ keyword:
 	keyword: Learn
 	match: learn
 	mode: action
-	reminder: You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.
+	reminder: {handle_action_rt(to:"learn", "you")} may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.
 keyword:
 	keyword: Ward
 	match: Ward <atom-param>cost</atom-param>
@@ -1541,7 +1541,7 @@ keyword:
 	keyword: Blood token
 	match: Blood toke<atom-param>*s</atom-param>
 	mode: expert
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "1, T, Discard a card, Sacrifice this artifact: Draw a card."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Blood token is an artifact")} with "1, T, Discard a card, Sacrifice this artifact: Draw a card."
 # Kamigawa Neon Dynasty
 keyword:
 	keyword: Reconfigure
@@ -1568,17 +1568,17 @@ keyword:
 	keyword: Connive
 	match: connive
 	mode: action
-	reminder: To have a creature connive, draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.
+	reminder: {handle_action_rt(to:"have a creature connive", "Draw")} a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on that creature.
 keyword:
 	keyword: Connives
 	match: connives
 	mode: action
-	reminder: Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on {this_or_that("creature")}.
+	reminder: {handle_action_rt(to:"have a creature connive", "Draw")} a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on {this_or_that("creature")}.
 keyword:
 	keyword: Connives N
 	match: connives <atom-param>number</atom-param>
 	mode: action
-	reminder: Draw {english_number_a(param1)} card(s), then discard {english_number_a(param1)} card(s). Put a +1/+1 counter on {this_or_that("creature")} for each nonland card discarded this way.
+	reminder: {handle_action_rt(to:"have a creature connive", "Draw")} {english_number_a(param1)} card(s), then discard {english_number_a(param1)} card(s). Put a +1/+1 counter on {this_or_that("creature")} for each nonland card discarded this way.
 keyword:
 	keyword: Blitz
 	match: Blitz <atom-param>cost</atom-param>
@@ -1647,7 +1647,7 @@ keyword:
 	keyword: Powerstone token
 	match: Powerstone toke<atom-param>*s</atom-param>
 	mode: expert
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "[T]: Add [C]. This mana can't be spent to cast a nonartifact spell."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Powerstone token is an artifact")} with "[T]: Add [C]. This mana can't be spent to cast a nonartifact spell."
 # Brother's War
 keyword:
 	keyword: Prototype
@@ -1690,7 +1690,7 @@ keyword:
 	keyword: Incubate
 	match: Incubate <atom-param>number</atom-param>
 	mode: action
-	reminder: Create an Incubator token with {english_number_a(param1)} +1/+1 counter(s) on it and "[2]: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.
+	reminder: {handle_action_rt(to:"incubate {param1}", "Create")} an Incubator token with {english_number_a(param1)} +1/+1 counter(s) on it and "[2]: Transform this artifact." It transforms into a 0/0 Phyrexian artifact creature.
 # Wilds of Eldraine
 keyword:
 	keyword: Bargain
@@ -1769,7 +1769,7 @@ keyword:
 	keyword: Map token
 	match: Map toke<atom-param>*s</atom-param>
 	mode: expert
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "1, T, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Map token is an artifact")} with "1, T, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery."
 keyword:
 	keyword: Craft
 	match: Craft with <atom-param>name</atom-param> <atom-param>cost</atom-param>
@@ -1794,7 +1794,7 @@ keyword:
 	keyword: Discover
 	match: Discover <atom-param>number</atom-param>
 	mode: action
-	reminder: Exile cards from the top of your library until you exile a nonland card with mana value {param1} or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.
+	reminder: {handle_action_rt(to:"discover {param1}", "Exile")} cards from the top of your library until you exile a nonland card with mana value {param1} or less. Cast it without paying its mana cost or put it into your hand. Put the rest on the bottom in a random order.
 keyword:
 	keyword: Finality counters
 	match: finality counter
@@ -1805,12 +1805,12 @@ keyword:
 	keyword: Cloak
 	match: cloak
 	mode: action
-	reminder: To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward [2]. Turn it face up any time for its mana cost if it's a creature card.
+	reminder: {handle_action_rt(to:"cloak a card", "Put")} it onto the battlefield face down as a 2/2 creature with ward [2]. Turn it face up any time for its mana cost if it's a creature card.
 keyword:
 	keyword: Collect evidence
 	match: collect evidence <atom-param>number</atom-param>
 	mode: action
-	reminder: Exile cards with total mana value {param1} or greater from your graveyard.
+	reminder: {handle_action_rt(to:"collect evidence {param1}", "Exile")} cards with total mana value {param1} or greater from your graveyard.
 keyword:
 	keyword: Disguise
 	match: Disguise <atom-param>cost</atom-param>
@@ -1831,7 +1831,7 @@ keyword:
 	keyword: Junk token
 	match: Junk toke<atom-param>*s</atom-param>
 	mode: expert
-	reminder: {if param1.value == "ns" then "They’re artifacts" else "It’s an artifact"} with "T, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery."
+	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Junk token is an artifact")} with "T, Sacrifice this artifact: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery."
 # Assassin's Creed
 keyword:
 	keyword: Freerunning
@@ -1890,12 +1890,12 @@ keyword:
 	keyword: forage
 	match: forage
 	mode: action
-	reminder: Exile three cards from your graveyard or sacrifice a Food.
+	reminder: {handle_action_rt(to:"forage", "Exile")} three cards from your graveyard or sacrifice a Food.
 keyword:
 	keyword: forage
 	match: foraging
 	mode: action
-	reminder: Exile three cards from your graveyard or sacrifice a Food.
+	reminder: {handle_action_rt(to:"forage", "Exile")} three cards from your graveyard or sacrifice a Food.
 keyword:
 	keyword: Gift a card
 	match: Gift a card

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -1178,6 +1178,16 @@ this_or_that := {
 
 	this_that + " " + type
 }@(upper:false)
+#### see if a keyword should have different text because it's merged with another reminder text
+#### handle_merged_rt("Its a", moved:"A Food token is")
+handle_merged_rt := {
+	"<use-if-moved>" + moved + "</use-if-moved><otherwise>" + input + "</otherwise>"
+}
+#### see if an action keyword should have different text because its distant from the keyword
+#### handle_action_rt(to:"forage", "Exile")
+handle_action_rt := {
+	"<use-if-bumped>To " + to + ", " + to_lower(input) + "</use-if-bumped><otherwise>" + input + "</otherwise>"
+}
 
 ############################################################## Complex reminder texts
 self_pro_check := match@(match:"You ha(ve|s) <kw-A><nospellcheck>protection")
@@ -1472,6 +1482,9 @@ text_filter :=
 	remove_tag@(tag: "<bullet>") +
 	remove_tag@(tag: "<align") +
 	remove_tag@(tag: "<margin") +
+	remove_tag@(tag: "<moved>") +
+	remove_tag@(tag: "<blob>") +
+	remove_tag@(tag: "<key>") +
 	#### step 1b : remove zero-width space used for level spacers
 	replace@(match:"​", replace:"") +
 	#### step 2a : temp fix for formatting buttons
@@ -1496,7 +1509,7 @@ text_filter :=
 			chosen(choice:if correct_case or mode == "action" then mode else "lower case", set.automatic_reminder_text) and chosen(choice:mode, set.automatic_reminder_text)
 		},
 		combine: {
-			keyword := "<nospellcheck>{keyword}</nospellcheck>"
+			keyword := "<nospellcheck><key>{keyword}</key></nospellcheck>"
 			reminder := process_english_hints(reminder)
 			if mode == "pseudo" then "<i-auto>{keyword}</i-auto>"
 			else keyword + if expand then "<atom-reminder-{mode}> ({reminder})</atom-reminder-{mode}>" else ""
@@ -1509,13 +1522,41 @@ text_filter :=
 	) +
 	#### step 2c : move action keywords' reminder text to the end of the line
 	replace@(
-		match: "(<atom-reminder-[^>]+> (?:(?!</kw).*?)</atom-reminder-[^>]+></kw[^>]*>)([^\n]*)", #### removed "| ?<kw-" from lookahead
+		match: "(<atom-reminder-[^>]+> (?:(?!</kw).*?)</atom-reminder-[^>]+></kw[^>]*>)([^\n]+)", #### removed "| ?<kw-" from lookahead
 		replace: "\\2\\1"
 	) +
 	#### step 2d : when there's an action keyword and another one, then move that to the end of the line
 	replace@(
 		match: "(<atom-reminder-[^>]+> (?:(?!</kw)[^\n]*?)</atom-reminder-[^>]+></kw[^>]*>)([^\n]*?)(<atom-reminder-[^>]+> (?:(?!</kw).*?)</atom-reminder-[^>]+></kw[^>]*>)([^\n]*)",
-		replace: "\\2\\4\\3\\1"
+		replace: "\\2<blob>\\4\\3<moved>\\1</moved></blob>"
+	) +
+	#### step 2da : apply multikeyword reminder edits
+		#### A Food token is... vs It's a...
+		#### this one moved
+	replace@(
+		match: "(<moved><atom-reminder[^>]*> [(])<use-if-(?:moved|bumped)>(.*?)</use-if-(?:moved|bumped)><otherwise>(.*?)</otherwise>",
+		replace: "\\1\\2"
+	) +
+		#### this one didn't
+	replace@(
+		match: "<use-if-moved>(.*?)</use-if-moved><otherwise>(.*?)</otherwise>",
+		replace: "\\2"
+	) +
+		#### To forage, exile... vs Exile...
+		#### this was put in a combined rt
+	replace@(
+		match: "(<blob>.*?)<use-if-bumped>(.*?)</use-if-bumped><otherwise>(.*?)</otherwise>",
+		replace: "\\1\\2"
+	) +
+		#### this one wasn't bumped
+	replace@(
+		match: "(</key></nospellcheck>[.]?<atom-reminder[^>]*> [(])<use-if-bumped>(.*?)</use-if-bumped><otherwise>(.*?)</otherwise>",
+		replace: "\\1\\3"
+	) +
+		#### this one was bumped
+	replace@(
+		match: "<use-if-bumped>(.*?)</use-if-bumped><otherwise>(.*?)</otherwise>",
+		replace: "\\1"
 	) +
 	#### step 2e : allow a sentence after lowercase reminder text for equips etc.
 	#replace@(
@@ -1529,7 +1570,7 @@ text_filter :=
 	) +
 	#### step 2g : combine reminder texts
 	replace@(
-		match: "[)](</atom-reminder-[^>]+></kw-[^>]><atom-reminder-[^>]+> )[(]"
+		match: "[)](</atom-reminder-[^>]+></kw-[^>]>(?:</?moved>)?<atom-reminder-[^>]+> )[(]"
 		replace: "\\1"
 	) +
 	#### step 2h : temp fix for formatting buttons

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -32,7 +32,7 @@ include file: language
 include file: statistics_script
 include file: /magic-blends.mse-include/new-blends
 ############################################################## Versioning
-version_date := {"2024-05-27 Mainframe 1.3.f Showcase Catchup: Module Rollout"}
+version_date := {"2024-05-27 Mainframe 1.3.g Showcase Catchup: Action Check"}
 version := version_date
 ############################################################## Common filters
 ############################################################## Utility


### PR DESCRIPTION
- added `handle_action_rt(to:"name", "Action")` to be used in keyword code. It will return either "To name, action" or "Action" depending on if the reminder text is removed from the keyword.
- Example: `{handle_action_rt(to:"populate", "Create")} a token that's a copy of a creature token you control.`
![image](https://github.com/user-attachments/assets/c8106eeb-36ec-429a-9d66-4abff8a04707)

* added `handle_merged_rt("Normal", moved:"Alternate")` to be used in keyword code. It will typically return "Normal", but will return "Alternate" if its keyword gets moved.
* Example: `{handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Food token is an artifact")} with "2, T, Sacrifice this artifact: You gain 3 life."`
![image](https://github.com/user-attachments/assets/d9835a64-35e2-4f65-9a95-ddfe6a19d0ee)
