### PR TITLE
Card symbol and transform symbol modifications

### DIFF
--- a/data/magic-modules.mse-include/card-symbols/card_fields
+++ b/data/magic-modules.mse-include/card-symbols/card_fields
@@ -1,6 +1,6 @@
 card style:
 	card symbol:
-		left:				{ card_symbol_left_1() + nameline_offset_left_1() }
+		left:				{ card_symbol_left_1() + name_transform_symbol_shift_1() + nameline_offset_left_1() }
 		top:				{ card_symbol_top_1() + nameline_offset_top_1() }
 		width:				{ card_symbol_width_1() + nameline_offset_height_1() }
 		height:				{ if card_symbol_disabled_1() then 0 else card_symbol_height_1() + nameline_offset_height_1() }
@@ -9,4 +9,4 @@ card style:
 		include file:		/magic.mse-game/card-symbols/menu_choice_images
 		render style:		image
 		image:				{ card_symbol_image(face: 1) }
-		z index:			810
+		z index:			871

--- a/data/magic-modules.mse-include/card-symbols/card_fields
+++ b/data/magic-modules.mse-include/card-symbols/card_fields
@@ -9,4 +9,4 @@ card style:
 		include file:		/magic.mse-game/card-symbols/menu_choice_images
 		render style:		image
 		image:				{ card_symbol_image(face: 1) }
-		z index:			871
+		z index:			870

--- a/data/magic-modules.mse-include/card-symbols/card_fields_dfc
+++ b/data/magic-modules.mse-include/card-symbols/card_fields_dfc
@@ -10,4 +10,4 @@ card style:
 		include file:		/magic.mse-game/card-symbols/menu_choice_images
 		render style:		image
 		image:				{ card_symbol_image(face: 2) }
-		z index:			871
+		z index:			870

--- a/data/magic-modules.mse-include/card-symbols/card_fields_dfc
+++ b/data/magic-modules.mse-include/card-symbols/card_fields_dfc
@@ -1,7 +1,7 @@
 include file: /magic-modules.mse-include/card-symbols/card_fields
 card style:
 	card symbol 2:
-		left:				{ card_symbol_left_2() + nameline_offset_left_2() }
+		left:				{ card_symbol_left_2() + name_transform_symbol_shift_2() + nameline_offset_left_2() }
 		top:				{ card_symbol_top_2() + nameline_offset_top_2() }
 		width:				{ card_symbol_width_2() + nameline_offset_height_2() }
 		height:				{ if card_symbol_disabled_2() then 0 else card_symbol_height_2() + nameline_offset_height_2() }
@@ -10,4 +10,4 @@ card style:
 		include file:		/magic.mse-game/card-symbols/menu_choice_images
 		render style:		image
 		image:				{ card_symbol_image(face: 2) }
-		z index:			810
+		z index:			871

--- a/data/magic-modules.mse-include/card-symbols/card_fields_tfc
+++ b/data/magic-modules.mse-include/card-symbols/card_fields_tfc
@@ -1,7 +1,7 @@
 include file: /magic-modules.mse-include/card-symbols/card_fields_dfc
 card style:
 	card symbol 3:
-		left:				{ card_symbol_left_3() + nameline_offset_left_3() }
+		left:				{ card_symbol_left_3() + name_transform_symbol_shift_3() + nameline_offset_left_3() }
 		top:				{ card_symbol_top_3() + nameline_offset_top_3() }
 		width:				{ card_symbol_width_3() + nameline_offset_height_3() }
 		height:				{ if card_symbol_disabled_3() then 0 else card_symbol_height_3() + nameline_offset_height_3() }
@@ -10,4 +10,4 @@ card style:
 		include file:		/magic.mse-game/card-symbols/menu_choice_images
 		render style:		image
 		image:				{ card_symbol_image(face: 3) }
-		z index:			810
+		z index:			871

--- a/data/magic-modules.mse-include/card-symbols/card_fields_tfc
+++ b/data/magic-modules.mse-include/card-symbols/card_fields_tfc
@@ -10,4 +10,4 @@ card style:
 		include file:		/magic.mse-game/card-symbols/menu_choice_images
 		render style:		image
 		image:				{ card_symbol_image(face: 3) }
-		z index:			871
+		z index:			870

--- a/data/magic-modules.mse-include/casting-costs/card_fields
+++ b/data/magic-modules.mse-include/casting-costs/card_fields
@@ -1,6 +1,6 @@
 card style:
 	casting cost:
-		right:				{ casting_cost_right_1() + nameline_offset_left_1() + nameline_offset_width_1() }
+		right:				{ casting_cost_right_1() + casting_cost_transform_symbol_shift_1() + nameline_offset_left_1() + nameline_offset_width_1() }
 		top:				{ casting_cost_top_1() + nameline_offset_top_1() }
 		width:				{ casting_cost_width_1() }
 		height:				{ casting_cost_height_1() + nameline_offset_height_1() }

--- a/data/magic-modules.mse-include/casting-costs/card_fields_dfc
+++ b/data/magic-modules.mse-include/casting-costs/card_fields_dfc
@@ -1,7 +1,7 @@
 include file: /magic-modules.mse-include/casting-costs/card_fields
 card style:
 	casting cost 2:
-		right:				{ casting_cost_right_2() + nameline_offset_left_2() + nameline_offset_width_2() }
+		right:				{ casting_cost_right_2() + casting_cost_transform_symbol_shift_2() + nameline_offset_left_2() + nameline_offset_width_2() }
 		top:				{ casting_cost_top_2() + nameline_offset_top_2() }
 		width:				{ casting_cost_width_2() }
 		height:				{ casting_cost_height_2() + nameline_offset_height_2() }

--- a/data/magic-modules.mse-include/casting-costs/card_fields_tfc
+++ b/data/magic-modules.mse-include/casting-costs/card_fields_tfc
@@ -1,7 +1,7 @@
 include file: /magic-modules.mse-include/casting-costs/card_fields_dfc
 card style:
 	casting cost 3:
-		right:				{ casting_cost_right_3() + nameline_offset_left_3() + nameline_offset_width_3() }
+		right:				{ casting_cost_right_3() + casting_cost_transform_symbol_shift_3() + nameline_offset_left_3() + nameline_offset_width_3() }
 		top:				{ casting_cost_top_3() + nameline_offset_top_3() }
 		width:				{ casting_cost_width_3() }
 		height:				{ casting_cost_height_3() + nameline_offset_height_3() }

--- a/data/magic-modules.mse-include/namelines/readme.txt
+++ b/data/magic-modules.mse-include/namelines/readme.txt
@@ -57,7 +57,8 @@ transform_symbol_offset_width_1 := { 0 }
 transform_symbol_offset_height_1 := { 0 }
 
 #### You can increase/decrease the amount by which the name shifts left
-#### when a transformation symbol is present on the card:
+#### when a card symbol or a transformation symbol is present on the card:
+name_card_symbol_offset_left_1 := { 0 }
 name_transform_symbol_offset_left_1 := { 0 }
 
 #### For DFC or TFC templates, use:

--- a/data/magic-modules.mse-include/readme.txt
+++ b/data/magic-modules.mse-include/readme.txt
@@ -9,9 +9,9 @@
 0300:	trim			#### Effects like vehicle, nyx, and snow that don't spill over the border
 0400:	pinline			#### Colored pinlines, pride pinlines
 0500:	border			#### Border
-0600:	plate editing	#### Major frame pieces: Transform sym/Lesson/Spree handling, Adventure pages, movable typelines
+0600:	plate editing	#### Major frame pieces: Lesson/Spree handling, Adventure pages, movable typelines
 0700:	watermarking	#### Watermarks, loyalty ability stripes, flavor bar, pop-under art (ex: WAR JP Tamiyo's popout goes under the rarity symbol)
-0800:	attachments		#### Optional frame additions: Crown, ptbox, level arrows, loyalty boxes, stamps, color indicators, alias box, flash dot
+0800:	attachments		#### Optional frame additions: Crown, ptbox, level arrows, loyalty boxes, stamps, color indicators, transformation symbols, alias box, flash dot
 0900:	text			#### Any text, rarity symbol
 1000:	overlays		#### Popout art, foiling and other overlay packages
 1100:	corners			#### These must always be last
@@ -59,7 +59,6 @@ Specific z indexes
 
 600 Moveable name/typelines
 610 Name/type caps (spree attachment)
-620 Transform symbol
 620 Adventure page
 640 Leveler backgrounds
 
@@ -76,6 +75,7 @@ Specific z indexes
 840 PT Box, Leveler arrows, Flash dot
 850 Color stamp
 860 Holofoil stamp
+870 Transform symbol
 880 Alias box
 
 900 Loyalty cost colons

--- a/data/magic-modules.mse-include/symbols/card_fields
+++ b/data/magic-modules.mse-include/symbols/card_fields
@@ -9,4 +9,4 @@ card style:
 		include file:		/magic.mse-game/symbols/menu_choice_images
 		render style:		image
 		image:				{ transform_symbol_image(face: 1) }
-		z index:			620
+		z index:			870

--- a/data/magic-modules.mse-include/symbols/card_fields_dfc
+++ b/data/magic-modules.mse-include/symbols/card_fields_dfc
@@ -10,4 +10,4 @@ card style:
 		include file:		/magic.mse-game/symbols/menu_choice_images
 		render style:		image
 		image:				{ transform_symbol_image(face: 2) }
-		z index:			620
+		z index:			870

--- a/data/magic-modules.mse-include/symbols/card_fields_tfc
+++ b/data/magic-modules.mse-include/symbols/card_fields_tfc
@@ -10,4 +10,4 @@ card style:
 		include file:		/magic.mse-game/symbols/menu_choice_images
 		render style:		image
 		image:				{ transform_symbol_image(face: 3) }
-		z index:			620
+		z index:			870

--- a/data/magic-modules.mse-include/symbols/readme.txt
+++ b/data/magic-modules.mse-include/symbols/readme.txt
@@ -42,6 +42,9 @@ transform_symbol_offset_height_1 := { 0 }
 #### To move the symbol to the right of the card:
 transform_symbol_mirrored_1 := { true }
 
+#### When the symbol is on the right of the card, transform_symbol_offset_left_1's effect if flipped
+#### (Positive numbers will shift to the left)
+
 #### For the other faces on DFCs use:
 transform_symbol_offset_top_2 := { 0 }
 transform_symbol_offset_left_2 := { 0 }

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -3082,6 +3082,7 @@ transform_symbol_left :=
 {
 	map := face_coordinates_map(face)
 	mirrored := transform_symbol_is_mirrored(1)
+	if mirrored then offset := -offset
 	if map.width > map.height then
 	(
 		if mirrored then	map.left + 455 * map.width/523 + offset
@@ -3166,13 +3167,7 @@ card_symbol_image := {
 card_symbol_left :=
 {
 	map := face_coordinates_map(face)
-	has_tr := (transform_symbol_field(face) != "none")
-	has_sym := (card_symbol_field(face) != "none")
-	default := if has_tr
-					then 8 + 18 + 28
-				else if has_sym
-					then 8 + 18
-				else 8
+	default := 8 + (if card_symbol_field(face) != "none" then 18 else 0)
 	if map.width > map.height then map.left + default * map.width/523 + offset
 	else                           map.left + default * map.width/375 + offset
 }
@@ -3911,6 +3906,17 @@ casting_cost_height :=
 	map := face_coordinates_map(face)
 	26 * min(map.width, map.height)/375 + offset
 }
+
+casting_cost_transform_symbol_shift :=
+{
+	if transform_symbol_field(face) == "none" or disabled
+		then 0
+	else (
+		map := face_coordinates_map(face)
+		29 * -(min(map.width, map.height)/375) - offset
+	)
+}
+
 casting_cost_disabled_1 := { false }
 casting_cost_offset_top_1 := { 0 }
 casting_cost_offset_left_1 := { 0 }
@@ -3920,6 +3926,7 @@ casting_cost_right_1 :=  { casting_cost_right(face:nameline_face_1(),  offset:ca
 casting_cost_top_1 :=    { casting_cost_top(face:nameline_face_1(),    offset:casting_cost_offset_top_1())    }
 casting_cost_width_1 :=  { casting_cost_width(face:nameline_face_1(),  offset:casting_cost_offset_width_1())  }
 casting_cost_height_1 := { casting_cost_height(face:nameline_face_1(), offset:casting_cost_offset_height_1()) }
+casting_cost_transform_symbol_shift_1 := { casting_cost_transform_symbol_shift(face:nameline_face_1(), offset:name_transform_symbol_offset_left_1() + nameline_offset_height_1(), disabled:transform_symbol_disabled_1() or (not transform_symbol_mirrored_1())) }
 
 casting_cost_disabled_2 := { false }
 casting_cost_offset_top_2 := { 0 }
@@ -3930,6 +3937,7 @@ casting_cost_right_2 :=  { casting_cost_right(face:nameline_face_2(),  offset:ca
 casting_cost_top_2 :=    { casting_cost_top(face:nameline_face_2(),    offset:casting_cost_offset_top_2())    }
 casting_cost_width_2 :=  { casting_cost_width(face:nameline_face_2(),  offset:casting_cost_offset_width_2())  }
 casting_cost_height_2 := { casting_cost_height(face:nameline_face_2(), offset:casting_cost_offset_height_2()) }
+casting_cost_transform_symbol_shift_2 := { casting_cost_transform_symbol_shift(face:nameline_face_2(), offset:name_transform_symbol_offset_left_2() + nameline_offset_height_2(), disabled:transform_symbol_disabled_2() or (not transform_symbol_mirrored_2())) }
 
 casting_cost_disabled_3 := { false }
 casting_cost_offset_top_3 := { 0 }
@@ -3940,6 +3948,7 @@ casting_cost_right_3 :=  { casting_cost_right(face:nameline_face_3(),  offset:ca
 casting_cost_top_3 :=    { casting_cost_top(face:nameline_face_3(),    offset:casting_cost_offset_top_3())    }
 casting_cost_width_3 :=  { casting_cost_width(face:nameline_face_3(),  offset:casting_cost_offset_width_3())  }
 casting_cost_height_3 := { casting_cost_height(face:nameline_face_3(), offset:casting_cost_offset_height_3()) }
+casting_cost_transform_symbol_shift_3 := { casting_cost_transform_symbol_shift(face:nameline_face_3(), offset:name_transform_symbol_offset_left_3() + nameline_offset_height_3(), disabled:transform_symbol_disabled_3() or (not transform_symbol_mirrored_3())) }
 
 ############################################################## Name offsets
 name_left :=
@@ -3995,41 +4004,44 @@ name_offset_top_1 := { 0 }
 name_offset_left_1 := { 0 }
 name_offset_right_1 := { 0 }
 name_offset_height_1 := { 0 }
+name_card_symbol_offset_left_1 := { 0 }
 name_transform_symbol_offset_left_1 := { 0 }
 name_left_1 :=   { name_left(face:nameline_face_1(),   offset:name_offset_left_1())   }
 name_top_1 :=    { name_top(face:nameline_face_1(),    offset:name_offset_top_1())    }
 name_right_1 :=  { name_right(face:nameline_face_1(),  offset:name_offset_right_1())  }
 name_height_1 := { name_height(face:nameline_face_1(), offset:name_offset_height_1()) }
-name_card_symbol_shift_1 :=      { name_card_symbol_shift(face:nameline_face_1(), offset:name_transform_symbol_offset_left_1(), disabled:card_symbol_disabled_1()) }
-name_transform_symbol_shift_1 := { name_transform_symbol_shift(face:nameline_face_1(), offset:name_transform_symbol_offset_left_1() + nameline_offset_height_1(), disabled:transform_symbol_disabled_1()) }
+name_card_symbol_shift_1 :=      { name_card_symbol_shift(face:nameline_face_1(), offset:name_card_symbol_offset_left_1(), disabled:card_symbol_disabled_1()) }
+name_transform_symbol_shift_1 := { name_transform_symbol_shift(face:nameline_face_1(), offset:name_transform_symbol_offset_left_1() + nameline_offset_height_1(), disabled:transform_symbol_disabled_1() or transform_symbol_mirrored_1()) }
 
 name_disabled_2 := { false }
 name_offset_top_2 := { 0 }
 name_offset_left_2 := { 0 }
 name_offset_right_2 := { 0 }
 name_offset_height_2 := { 0 }
+name_card_symbol_offset_left_2 := { 0 }
 name_transform_symbol_offset_left_2 := { 0 }
 name_max_width_2 := { card_style.name_2.width }
 name_left_2 :=   { name_left(face:nameline_face_2(),   offset:name_offset_left_2())   }
 name_top_2 :=    { name_top(face:nameline_face_2(),    offset:name_offset_top_2())    }
 name_right_2 :=  { name_right(face:nameline_face_2(),  offset:name_offset_right_2())  }
 name_height_2 := { name_height(face:nameline_face_2(), offset:name_offset_height_2()) }
-name_card_symbol_shift_2 :=      { name_card_symbol_shift(face:nameline_face_2(), offset:name_transform_symbol_offset_left_2(), disabled:card_symbol_disabled_2()) }
-name_transform_symbol_shift_2 := { name_transform_symbol_shift(face:nameline_face_2(), offset:name_transform_symbol_offset_left_2() + nameline_offset_height_2(), disabled:transform_symbol_disabled_2()) }
+name_card_symbol_shift_2 :=      { name_card_symbol_shift(face:nameline_face_2(), offset:name_card_symbol_offset_left_2(), disabled:card_symbol_disabled_2()) }
+name_transform_symbol_shift_2 := { name_transform_symbol_shift(face:nameline_face_2(), offset:name_transform_symbol_offset_left_2() + nameline_offset_height_2(), disabled:transform_symbol_disabled_2() or transform_symbol_mirrored_2()) }
 
 name_disabled_3 := { false }
 name_offset_top_3 := { 0 }
 name_offset_left_3 := { 0 }
 name_offset_right_3 := { 0 }
 name_offset_height_3 := { 0 }
+name_card_symbol_offset_left_2 := { 0 }
 name_transform_symbol_offset_left_3 := { 0 }
 name_max_width_3 := { card_style.name_3.width }
 name_left_3 :=   { name_left(face:nameline_face_3(),   offset:name_offset_left_3())   }
 name_top_3 :=    { name_top(face:nameline_face_3(),    offset:name_offset_top_3())    }
 name_right_3 :=  { name_right(face:nameline_face_3(),  offset:name_offset_right_3())  }
 name_height_3 := { name_height(face:nameline_face_3(), offset:name_offset_height_3()) }
-name_card_symbol_shift_3 :=      { name_card_symbol_shift(face:nameline_face_3(), offset:name_transform_symbol_offset_left_3(), disabled:card_symbol_disabled_3()) }
-name_transform_symbol_shift_3 := { name_transform_symbol_shift(face:nameline_face_3(), offset:name_transform_symbol_offset_left_3() + nameline_offset_height_3(), disabled:transform_symbol_disabled_3()) }
+name_card_symbol_shift_3 :=      { name_card_symbol_shift(face:nameline_face_3(), offset:name_card_symbol_offset_left_3(), disabled:card_symbol_disabled_3()) }
+name_transform_symbol_shift_3 := { name_transform_symbol_shift(face:nameline_face_3(), offset:name_transform_symbol_offset_left_3() + nameline_offset_height_3(), disabled:transform_symbol_disabled_3() or transform_symbol_mirrored_3()) }
 
 ############################################################## Nameline offsets
 nameline_face_1 := { 1 }


### PR DESCRIPTION
- Move card symbols and transform symbols to 870 z index, so they are above crowns
- add `name_card_symbol_offset_left` variables to change by how much the name shifts when there is a card symbol
- mirror the effect of `transform_symbol_offset_left` when the transformation symbol is on the right side of the card (positive values shift it left)