### PR TITLE
Suggested fix for cright field error in Modern Doublefaced Planeswalker template

### DIFF
--- a/data/magic-new-planeswalker-doublefaced.mse-style/style
+++ b/data/magic-new-planeswalker-doublefaced.mse-style/style
@@ -681,19 +681,29 @@ extra card field:
 	save value: true
 	script:
 		if set.automatic_card_numbers then
-			forward_editor(field: card.copyright, suffix: " " + get_card_number_count(tag:card_number_tags().0) )
+			if set.automatic_copyright then
+				forward_editor(field: card.auto_copyright, suffix: " " + card.card_number )
+			else
+				forward_editor(field: card.copyright, suffix: " " + card.card_number )
 		else
-			forward_editor(field: card.copyright)
+			if set.automatic_copyright then
+				forward_editor(field: card.auto_copyright)
+			else
+				forward_editor(field: card.copyright)
+		# Console complained that get_card_number_count() was not defined, so I assume it is an artifact
+		# from the old version of the template, and that it was intended to be changed in an earlier update.
+		#
+		# Would be easier to just use card_number_old_1() here, but it causes a visual bug where a
+		# whitespace is missing between copyright and card number, and I would like explicit permission
+		# before making changes to game-template scripts.
 	description: Copyright of this card and cardnumber, the default value can be changed on the 'set info' tab
 extra card field:
 	type: text
 	name: cright line 2
 	save value: true
 	script:
-		if set.automatic_card_numbers then
-			forward_editor(field: card.copyright_2, suffix: " " + get_card_number_count(tag:card_number_tags().1) )
-		else
-			forward_editor(field: card.copyright_2)
+		card_number_old_2()
+		# Previous card count method is most likely deprecated.
 	description: Copyright of this card and cardnumber, the default value can be changed on the 'set info' tab
 extra card style:
 	paintbrush:

--- a/data/magic-new-planeswalker-doublefaced.mse-style/style
+++ b/data/magic-new-planeswalker-doublefaced.mse-style/style
@@ -679,31 +679,13 @@ extra card field:
 	type: text
 	name: cright line
 	save value: true
-	script:
-		if set.automatic_card_numbers then
-			if set.automatic_copyright then
-				forward_editor(field: card.auto_copyright, suffix: " " + card.card_number )
-			else
-				forward_editor(field: card.copyright, suffix: " " + card.card_number )
-		else
-			if set.automatic_copyright then
-				forward_editor(field: card.auto_copyright)
-			else
-				forward_editor(field: card.copyright)
-		# Console complained that get_card_number_count() was not defined, so I assume it is an artifact
-		# from the old version of the template, and that it was intended to be changed in an earlier update.
-		#
-		# Would be easier to just use card_number_old_1() here, but it causes a visual bug where a
-		# whitespace is missing between copyright and card number, and I would like explicit permission
-		# before making changes to game-template scripts.
+	script: card_number_old_1()
 	description: Copyright of this card and cardnumber, the default value can be changed on the 'set info' tab
 extra card field:
 	type: text
 	name: cright line 2
 	save value: true
-	script:
-		card_number_old_2()
-		# Previous card count method is most likely deprecated.
+	script:	card_number_old_2()
 	description: Copyright of this card and cardnumber, the default value can be changed on the 'set info' tab
 extra card style:
 	paintbrush:

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -2843,13 +2843,13 @@ card_number_old_1 := {
 	else if auto_copy then
 		combined_editor(
 			field1: card.auto_copyright,
-			separator: card.card_number,
+			separator: " " + card.card_number + " ",
 			field2: card.card_code_text
 		)
 	else
 		combined_editor(
 			field1: card.copyright,
-			separator: card.card_number,
+			separator: " " + card.card_number + " ",
 			field2: card.card_code_text
 		)
 }


### PR DESCRIPTION
extra card field: `cright line` made a call to `get_card_number_count(tag:card_number_tags().0)`
Console complaied that no such method exists

I assume it was an artifact from the old version of the template, and that it was intended to be changed in an earlier update.

Also, card_number_old_1() t causes a visual bug where a whitespace is missing between copyright and card number. Should i look into that?

Read code comments for more details