### PR TITLE
Suggested fix for Magic Sci-Fi Sync template crash

### DIFF
--- a/data/magic-sync.mse-style/style
+++ b/data/magic-sync.mse-style/style
@@ -334,9 +334,6 @@ extra card field:
 	name: card code
 	save value: false
 	script: card_code_script(value)
-	# card_code_script_core() crashed due to undefined value: face. Either the template is missing something to set the face-value of the template,
-	# or the method is called incorrectly (assuming that card_code_script_core() works as intended).
-	# I'm not sure if card_code_script(value) produces the same result as the core script, so maybe double check that.
 extra card field:
 	type: choice
 	name: artist arrow

--- a/data/magic-sync.mse-style/style
+++ b/data/magic-sync.mse-style/style
@@ -333,7 +333,10 @@ extra card field:
 	type: text
 	name: card code
 	save value: false
-	script: card_code_script_core()
+	script: card_code_script(value)
+	# card_code_script_core() crashed due to undefined value: face. Either the template is missing something to set the face-value of the template,
+	# or the method is called incorrectly (assuming that card_code_script_core() works as intended).
+	# I'm not sure if card_code_script(value) produces the same result as the core script, so maybe double check that.
 extra card field:
 	type: choice
 	name: artist arrow


### PR DESCRIPTION
extra card field: `card code` calls the method `card_code_script_core()` which causes the template to break completely.
Console gives following error:

> Variable not set: face
> in function card_code_script_core

This pull request makes a quick fix by replacing the called method with `card_code_script(value)`, but if someone who is more familiar with the template in question would prefer a different solution, we should probably look into that.

Read code comments for more details