### PR TITLE
fix set.inverted_common_symbol ot being used

### DIFF
--- a/data/magic-booster-mini.mse-style/style
+++ b/data/magic-booster-mini.mse-style/style
@@ -259,7 +259,7 @@ card style:
 					set_alpha(alpha: rarity_alpha(), 
 						if use_main_rarity() then mainframe_rarity("c")
 						else if alt_rarity() then alt_symbol()
-						else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+						else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 						else symbol_variation(symbol: set.symbol, variation: "common")
 					)
 			common:
@@ -267,7 +267,7 @@ card style:
 					set_alpha(alpha: rarity_alpha(), 
 						if use_main_rarity() then mainframe_rarity("c")
 						else if alt_rarity() then alt_symbol()
-						else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+						else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 						else symbol_variation(symbol: set.symbol, variation: "common")
 					)
 			uncommon:

--- a/data/magic-booster.mse-style/style
+++ b/data/magic-booster.mse-style/style
@@ -259,7 +259,7 @@ card style:
 					set_alpha(alpha: rarity_alpha(), 
 						if use_main_rarity() then mainframe_rarity("c")
 						else if alt_rarity() then alt_symbol()
-						else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+						else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 						else symbol_variation(symbol: set.symbol, variation: "common")
 					)
 			common:
@@ -267,7 +267,7 @@ card style:
 					set_alpha(alpha: rarity_alpha(), 
 						if use_main_rarity() then mainframe_rarity("c")
 						else if alt_rarity() then alt_symbol()
-						else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+						else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 						else symbol_variation(symbol: set.symbol, variation: "common")
 					)
 			uncommon:

--- a/data/magic-modules.mse-include/rarities/choice_images
+++ b/data/magic-modules.mse-include/rarities/choice_images
@@ -4,13 +4,13 @@ choice images:
 		script:
 			if use_main_rarity() then mainframe_rarity("c")
 			else if use_alt_rarity() then alt_symbol()
-			else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+			else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 			else symbol_variation(symbol: set.symbol, variation: "common")
 	common:
 		script:
 			if use_main_rarity() then mainframe_rarity("c")
 			else if use_alt_rarity() then alt_symbol()
-			else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+			else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 			else symbol_variation(symbol: set.symbol, variation: "common")
 	uncommon:
 		script:

--- a/data/magic-modules.mse-include/rarities/choice_images_old
+++ b/data/magic-modules.mse-include/rarities/choice_images_old
@@ -4,13 +4,13 @@ choice images:
 		script:
 			if use_main_rarity() then mainframe_rarity("c")
 			else if use_alt_rarity() then alt_symbol()
-			else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+			else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 			else symbol_variation(symbol: set.symbol, variation: "common")
 	common:
 		script:
 			if use_main_rarity() then mainframe_rarity("c")
 			else if use_alt_rarity() then alt_symbol()
-			else if styling.inverted_common_symbol or else set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
+			else if styling.inverted_common_symbol or else false or set.inverted_common_symbol then symbol_variation(symbol: set.symbol, variation: "invertedcommon")
 			else symbol_variation(symbol: set.symbol, variation: "common")
 	uncommon:
 		script:


### PR DESCRIPTION
styling.inverted_common_symbol or else set.inverted_common_symbol means set.inverted_common_symbol is ignore if styling.inverted_common_symbol exists. making this styling.inverted_common_symbol or else false or set.inverted_common_symbol properly checks both