### PR TITLE
add vorthos box to info module

### DIFF
--- a/data/magic-modules.mse-include/information/card_fields
+++ b/data/magic-modules.mse-include/information/card_fields
@@ -686,7 +686,7 @@ card style:
 			script:
 				if face_is_rotated(1) then
 				(
-					(if card.pt != "" or card.loyalty != "" then 21 + information_secondary_offset_pt_left_1() else if card.secondary_copyright != "" then 23 else 33) * face_coordinates_map(1).width/523 +
+					(if card.pt != "" or card.loyalty != "" then 21 + information_secondary_offset_pt_left_1() else if card.secondary_copyright != "" or card.vorthos_box != "" then 23 else 33) * face_coordinates_map(1).width/523 +
 					face_coordinates_map(1).left - information_offset_top_1()
 				) else (
 					351 * face_coordinates_map(1).width/375 + face_coordinates_map(1).left + information_copyright_offset_right_1()
@@ -697,7 +697,7 @@ card style:
 				(
 					351 * face_coordinates_map(1).height/375 + face_coordinates_map(1).top + information_copyright_offset_right_1()
 				) else (
-					(if information_secondary_shift_with_pt_1() and (card.pt != "" or card.loyalty != "") then 502 + information_copyright_offset_pt_top_1() else if card.secondary_copyright != "" then 500 else 490) * face_coordinates_map(1).height/523 +
+					(if information_secondary_shift_with_pt_1() and (card.pt != "" or card.loyalty != "") then 502 + information_copyright_offset_pt_top_1() else if card.secondary_copyright != "" or card.vorthos_box != "" then 500 else 490) * face_coordinates_map(1).height/523 +
 					face_coordinates_map(1).top + information_offset_top_1()
 				)
 		width:
@@ -730,7 +730,7 @@ card style:
 			script:
 				if face_is_rotated(1) then
 				(
-					(if card.pt != "" or card.loyalty != "" then 21 + information_secondary_offset_pt_left_1() else if card.secondary_copyright != "" then 23 else 33) * face_coordinates_map(1).width/523 + face_coordinates_map(1).left - information_offset_top_1()
+					(if card.pt != "" or card.loyalty != "" then 21 + information_secondary_offset_pt_left_1() else if card.secondary_copyright != "" or card.vorthos_box != "" then 23 else 33) * face_coordinates_map(1).width/523 + face_coordinates_map(1).left - information_offset_top_1()
 				) else (
 					351 * face_coordinates_map(1).width/375 + face_coordinates_map(1).left + information_copyright_offset_right_1()
 				)
@@ -740,7 +740,7 @@ card style:
 				(
 					351 * face_coordinates_map(1).height/375 + face_coordinates_map(1).top + information_copyright_offset_right_1()
 				) else (
-					(if information_secondary_shift_with_pt_1() and (card.pt != "" or card.loyalty != "") then 502 + information_copyright_offset_pt_top_1() else if card.secondary_copyright != "" then 500 else 490) * face_coordinates_map(1).height/523 + face_coordinates_map(1).top + information_offset_top_1()
+					(if information_secondary_shift_with_pt_1() and (card.pt != "" or card.loyalty != "") then 502 + information_copyright_offset_pt_top_1() else if card.secondary_copyright != "" or card.vorthos_box != "" then 500 else 490) * face_coordinates_map(1).height/523 + face_coordinates_map(1).top + information_offset_top_1()
 				)
 		width:
 			script:
@@ -790,7 +790,7 @@ card style:
 			script:
 				if face_is_rotated(1) then
 				(
-					140 * face_coordinates_map(1).width/523
+					(if card.secondary_copyright == "" and card.vorthos_box == "" then 70 else 140) * face_coordinates_map(1).width/523
 				) else (
 					needed := (255 + information_secondary_offset_pt_left_1() - if length(card.secondary_copyright) > 9 then 45 else if length(card.secondary_copyright) > 6 then 25 else if length(card.secondary_copyright) > 4 then 10 else 0) * face_coordinates_map(1).width/375 + face_coordinates_map(1).left
 					aligned := 351 * face_coordinates_map(1).width/375 + information_copyright_offset_right_1() - (if set.automatic_copyright then card_style.auto_copyright.content_width else card_style.copyright.content_width) + face_coordinates_map(1).left
@@ -813,5 +813,79 @@ card style:
 			size:				{ 6.5 * face_coordinates_map(1).height/(if face_is_rotated(1) then 375 else 523) }
 			color:				{ styling.copyright_text_color or else set.copyright_text_color }
 			weight:				bold
-		z index:			900
+		z index:			910
+	vorthos box:
+		angle:				{ if face_is_rotated(1) then -90 else 0 }
+		right:
+			script:
+				if face_is_rotated(1) then
+				(
+					(if card.secondary_copyright == "" then 33 else if (card.copyright == "" and set.copyright == "") then 23 else 12) * face_coordinates_map(1).width/523 + face_coordinates_map(1).left - information_offset_top_1()
+				) else (
+					edge_c := 351
+					pt_shift := false
+					if card.secondary_copyright == "" and information_secondary_shift_with_pt_1() then (
+						if card.pt != "" then (
+							edge_c := 278 + information_secondary_offset_pt_left_1()
+							pt_shift := true
+						)
+						else if card.loyalty != "" then (
+							edge_c := 295 + information_secondary_offset_pt_left_1()
+							pt_shift := true
+						)
+					)
+					if card.secondary_copyright == "" then (
+						## VB is at lv 1, C is lv1 or 2
+						if card.vorthos_box == "" and pt_shift
+							then edge_c := edge_c + 4
+					)
+					else (
+						## C is at lv 2, VB is lv2 or 3
+						if card.vorthos_box == "" and not set.automatic_copyright and card.copyright == ""
+							then edge_c := edge_c + 4
+					)
+					edge_c * face_coordinates_map(1).width/375 + face_coordinates_map(1).left + information_copyright_offset_right_1()
+				)
+		top:
+			script:
+				if face_is_rotated(1) then
+				(
+					(if card.secondary_copyright == "" and card.vorthos_box == "" then 370 else 351) * face_coordinates_map(1).height/375 + face_coordinates_map(1).top + information_copyright_offset_right_1()
+				) else (
+					top_c := 490 # lv 1, used if no SC
+					if card.secondary_copyright != "" then (
+						## VB is lv3 if C is used, otherwise 2
+						if card.copyright != "" or (set.automatic_copyright and set.copyright != "")
+							then top_c := 510 + (if information_secondary_shift_with_pt_1() and (card.pt != "" or card.loyalty != "") then 2 + information_copyright_offset_pt_top_1() else 0)
+						else top_c := 500
+					)
+					top_c * face_coordinates_map(1).height/523 + face_coordinates_map(1).top + information_offset_top_1()
+				)
+		width:
+			script:
+				if face_is_rotated(1) then
+				(
+					(if card.secondary_copyright == "" and card.vorthos_box == "" then 15 else 70) * face_coordinates_map(1).width/523
+				) else (
+					w := if card.secondary_copyright == "" and information_secondary_shift_with_pt_1() and (card.pt != "" or card.loyalty != "")
+							then (if card.vorthos_box != "" then 45 else 15)
+						 else 70
+					w * face_coordinates_map(1).width/375
+				)
+		height:
+			script:
+				if face_is_rotated(1) then
+				(
+					if information_disabled_1() then 0 else 10 * face_coordinates_map(1).height/375
+				) else (
+					if information_disabled_1() then 0 else 10 * face_coordinates_map(1).height/523
+				)
+		visible:			{ not information_disabled_1() }
+		alignment:			middle right
+		font:
+			name:				Relay-Medium
+			size:				{ 7 * face_coordinates_map(1).height/(if face_is_rotated(1) then 375 else 523) }
+			color:				{ styling.copyright_text_color or else set.copyright_text_color }
+			weight:				bold
+		z index:			920
 include file: /magic-modules.mse-include/information/list_field

--- a/data/magic-modules.mse-include/information/card_fields_dfc
+++ b/data/magic-modules.mse-include/information/card_fields_dfc
@@ -342,7 +342,7 @@ card style:
 			script:
 				if face_is_rotated(2) then
 				(
-					(if card.pt_2 != "" or card.loyalty_2 != "" then 21 + information_secondary_offset_pt_left_2() else if card.secondary_copyright_2 != "" then 23 else 33) * face_coordinates_map(2).width/523 + face_coordinates_map(2).left - information_offset_top_2()
+					(if card.pt_2 != "" or card.loyalty_2 != "" then 21 + information_secondary_offset_pt_left_2() else if card.secondary_copyright_2 != "" or card.vorthos_box_2 != "" then 23 else 33) * face_coordinates_map(2).width/523 + face_coordinates_map(2).left - information_offset_top_2()
 				) else (
 					351 * face_coordinates_map(2).width/375 + face_coordinates_map(2).left + information_copyright_offset_right_2()
 				)
@@ -352,7 +352,7 @@ card style:
 				(
 					351 * face_coordinates_map(2).height/375 + face_coordinates_map(2).top + information_copyright_offset_right_2()
 				) else (
-					(if card.pt_2 != "" or card.loyalty_2 != "" then 502 + information_copyright_offset_pt_top_2() else if card.secondary_copyright_2 != "" then 500 else 490) * face_coordinates_map(2).height/523 + face_coordinates_map(2).top + information_offset_top_2()
+					(if card.pt_2 != "" or card.loyalty_2 != "" then 502 + information_copyright_offset_pt_top_2() else if card.secondary_copyright_2 != "" or card.vorthos_box_2 != "" then 500 else 490) * face_coordinates_map(2).height/523 + face_coordinates_map(2).top + information_offset_top_2()
 				)
 		width:
 			script:
@@ -384,7 +384,7 @@ card style:
 			script:
 				if face_is_rotated(2) then
 				(
-					(if card.pt_2 != "" or card.loyalty_2 != "" then 21 + information_secondary_offset_pt_left_2() else if card.secondary_copyright_2 != "" then 23 else 33) * face_coordinates_map(2).width/523 + face_coordinates_map(2).left - information_offset_top_2()
+					(if card.pt_2 != "" or card.loyalty_2 != "" then 21 + information_secondary_offset_pt_left_2() else if card.secondary_copyright_2 != "" or card.vorthos_box_2 != "" then 23 else 33) * face_coordinates_map(2).width/523 + face_coordinates_map(2).left - information_offset_top_2()
 				) else (
 					351 * face_coordinates_map(2).width/375 + face_coordinates_map(2).left + information_copyright_offset_right_2()
 				)
@@ -394,7 +394,7 @@ card style:
 				(
 					351 * face_coordinates_map(2).height/375 + face_coordinates_map(2).top + information_copyright_offset_right_2()
 				) else (
-					(if card.pt_2 != "" or card.loyalty_2 != "" then 502 + information_copyright_offset_pt_top_2() else if card.secondary_copyright_2 != "" then 500 else 490) * face_coordinates_map(2).height/523 + face_coordinates_map(2).top + information_offset_top_2()
+					(if card.pt_2 != "" or card.loyalty_2 != "" then 502 + information_copyright_offset_pt_top_2() else if card.secondary_copyright_2 != "" or card.vorthos_box_2 != "" then 500 else 490) * face_coordinates_map(2).height/523 + face_coordinates_map(2).top + information_offset_top_2()
 				)
 		width:
 			script:
@@ -444,7 +444,7 @@ card style:
 			script:
 				if face_is_rotated(2) then
 				(
-					140 * face_coordinates_map(2).width/523
+					(if card.secondary_copyright_2 == "" and card.vorthos_box_2 == "" then 70 else 140) * face_coordinates_map(2).width/523
 				) else (
 					needed := (255 + information_secondary_offset_pt_left_2() - if length(card.secondary_copyright_2) > 9 then 45 else if length(card.secondary_copyright_2) > 6 then 25 else if length(card.secondary_copyright_2) > 4 then 10 else 0) * face_coordinates_map(2).width/375 + face_coordinates_map(2).left
 					aligned := 351 * face_coordinates_map(2).width/375 + information_copyright_offset_right_2() - (if set.automatic_copyright then card_style.auto_copyright_2.content_width else card_style.copyright_2.content_width) + face_coordinates_map(2).left
@@ -467,5 +467,79 @@ card style:
 			size:				{ 6.5 * face_coordinates_map(2).height/(if face_is_rotated(2) then 375 else 523) }
 			color:				{ styling.copyright_text_color or else set.copyright_text_color }
 			weight:				bold
-		z index:			900
+		z index:			910
+	vorthos box 2:
+		angle:				{ if face_is_rotated(2) then -90 else 0 }
+		right:
+			script:
+				if face_is_rotated(2) then
+				(
+					(if card.secondary_copyright_2 == "" then 33 else if (card.copyright_2 == "" and set.copyright == "") then 23 else 12) * face_coordinates_map(2).width/523 + face_coordinates_map(2).left - information_offset_top_2()
+				) else (
+					edge_c := 351
+					pt_shift := false
+					if card.secondary_copyright_2 == "" and information_secondary_shift_with_pt_2() then (
+						if card.pt_2 != "" then (
+							edge_c := 278 + information_secondary_offset_pt_left_2()
+							pt_shift := true
+						)
+						else if card.loyalty_2 != "" then (
+							edge_c := 295 + information_secondary_offset_pt_left_2()
+							pt_shift := true
+						)
+					)
+					if card.secondary_copyright_2 == "" then (
+						## VB is at lv 1, C is lv1 or 2
+						if card.vorthos_box_2 == "" and pt_shift
+							then edge_c := edge_c + 4
+					)
+					else (
+						## C is at lv 2, VB is lv2 or 3
+						if card.vorthos_box_2 == "" and not set.automatic_copyright and card.copyright_2 == ""
+							then edge_c := edge_c + 4
+					)
+					edge_c * face_coordinates_map(2).width/375 + face_coordinates_map(2).left + information_copyright_offset_right_2()
+				)
+		top:
+			script:
+				if face_is_rotated(2) then
+				(
+					(if card.secondary_copyright_2 == "" and card.vorthos_box_2 == "" then 370 else 351) * face_coordinates_map(2).height/375 + face_coordinates_map(2).top + information_copyright_offset_right_2()
+				) else (
+					top_c := 490 # lv 1, used if no SC
+					if card.secondary_copyright_2 != "" then (
+						## VB is lv3 if C is used, otherwise 2
+						if card.copyright_2 != "" or (set.automatic_copyright and set.copyright != "")
+							then top_c := 510 + (if information_secondary_shift_with_pt_2() and (card.pt_2 != "" or card.loyalty_2 != "") then 2 + information_copyright_offset_pt_top_2() else 0)
+						else top_c := 500
+					)
+					top_c * face_coordinates_map(2).height/523 + face_coordinates_map(2).top + information_offset_top_2()
+				)
+		width:
+			script:
+				if face_is_rotated(2) then
+				(
+					(if card.secondary_copyright_2 == "" and card.vorthos_box_2 == "" then 15 else 70) * face_coordinates_map(2).width/523
+				) else (
+					w := if card.secondary_copyright_2 == "" and information_secondary_shift_with_pt_2() and (card.pt_2 != "" or card.loyalty_2 != "")
+							then (if card.vorthos_box_2 != "" then 45 else 15)
+						 else 70
+					w * face_coordinates_map(2).width/375
+				)
+		height:
+			script:
+				if face_is_rotated(2) then
+				(
+					if information_disabled_2() then 0 else 10 * face_coordinates_map(2).height/375
+				) else (
+					if information_disabled_2() then 0 else 10 * face_coordinates_map(2).height/523
+				)
+		visible:			{ not information_disabled_2() }
+		alignment:			middle right
+		font:
+			name:				Relay-Medium
+			size:				{ 7 * face_coordinates_map(2).height/(if face_is_rotated(2) then 375 else 523) }
+			color:				{ styling.copyright_text_color or else set.copyright_text_color }
+			weight:				bold
+		z index:			920
 include file: /magic-modules.mse-include/information/list_field_dfc

--- a/data/magic.mse-game/card_fields
+++ b/data/magic.mse-game/card_fields
@@ -3217,7 +3217,7 @@ card field:
 	card list name: Vorthos Box
 	card list column: 1223
 	card list width: 150
-	script: extra_card.vorthos_box or else ""
+	script: if value == "" then extra_card.vorthos_box or else "" else value
 card field:
 	type: text
 	name: vorthos box 2
@@ -3226,7 +3226,7 @@ card field:
 	card list name: Vorthos Box 2
 	card list column: 1224
 	card list width: 150
-	script: extra_card.vorthos_box_2 or else ""
+	script: if value == "" then extra_card.vorthos_box_2 or else "" else value
 
 ############################################################## Old frame copyright line
 card field:


### PR DESCRIPTION
"Vorthos Box" was an extra field added to Mainframe to support the "mtgvorthos.com" bit of story spotlights, and was often used as a Pronoun box. Secondary Copyright threw a bit of a wrench at that by sitting in the same place but having a different font and alignment, and sometimes you want all three anyway.

If Secondary Copyright (SC) is empty, put Vorthos Box (VB) at the same height, but shifted slightly right, so both are clickable. If VB is also empty, Auto/Manual Copyright (AC/MC) will go at the same height, otherwise it will go down a level. VB's offset is exaggerated on Rotated frames, while MC is much longer on Normal frames, allowing all three to be clickable when overlaid.

If SC is not empty, MC is placed at the level underneath it. If MC/AC is also not empty, VB will be put on the third level. If AC is disabled, MC is empty, and VB is empty, VB will be put on the second level, but offset to the right, overlaying MC and VB but allowing both to be clicked.

3.1 release will want an update to mse-editor to convert extra_field Vorthos Boxes to card_field, then 4.0 will want to remove the extra_field versions from templates.