### PR TITLE
fixed case sensitivity in symbol font file references

### DIFF
--- a/data/magic-mana-large.mse-symbol-font/symbol-font
+++ b/data/magic-mana-large.mse-symbol-font/symbol-font
@@ -178,7 +178,7 @@ symbol:
 	image: mana_q.png
 symbol:
 	code: E
-	image: Energy.png
+	image: energy.png
 	image font size: 230
 symbol:
 	code: A-


### PR DESCRIPTION
This doesn't really matter on Windows, but on case-sensitive filesystems it could cause issues.

It's an extremely minor fix, mostly borne out of encountering the issue.