### PR TITLE
optional parameter support

### DIFF
--- a/data/magic.mse-game/keywords_en
+++ b/data/magic.mse-game/keywords_en
@@ -173,6 +173,24 @@ keyword parameter type:
 	separator before is: [^>]([Pp]ays?( an additional| any amount of)?|gets?( that many)?)[ ]
 	reminder script: length(input)
 
+keyword parameter type:
+	name: optional_number
+	match: [ ]?[XYZ0-9%]+
+	optional: true
+	placeholder: hidden
+	refer script:
+		name: corrected value
+		script: \{clear_optional_placeholder({input})\}
+
+keyword parameter type:
+	name: plural
+	match: s|es|ies|en
+	optional: true
+	placeholder: hidden
+	refer script:
+		name: is plural
+		script: \{is_plural({input})\}
+
 ############################# All Magic keywords
 # By JrEye and Neko_Asakami, Updated by Pichoro and Buttock1234, Continued updates by cajun
 
@@ -1335,9 +1353,9 @@ keyword:
 	reminder: {param1}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand or the command zone tapped and attacking.
 keyword:
 	keyword: Treasure token
-	match: Treasure toke<atom-param>*s</atom-param>
+	match: Treasure token<atom-param>plural</atom-param>
 	mode: core
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Treasure token is an artifact")} with "T, Sacrifice this token: Add one mana of any color."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Treasure token is an artifact")} with "T, Sacrifice this token: Add one mana of any color."
 #Guilds of Ravnica
 keyword:
 	keyword: Jump-start
@@ -1403,9 +1421,9 @@ keyword:
 	rules: Adamant — If at least three [color] mana was spent to cast this spell, [effect].
 keyword:
 	keyword: Food token
-	match: Food toke<atom-param>*s</atom-param>
+	match: Food token<atom-param>plural</atom-param>
 	mode: core
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Food token is an artifact")} with "2, T, Sacrifice this token: You gain 3 life."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Food token is an artifact")} with "2, T, Sacrifice this token: You gain 3 life."
 #Theros Beyond Death
 keyword:
 	keyword: Escape
@@ -1414,9 +1432,9 @@ keyword:
 	reminder: You may cast this card from your graveyard for its escape cost.
 keyword:
 	keyword: Gold token
-	match: Gold toke<atom-param>*s</atom-param>
+	match: Gold token<atom-param>plural</atom-param>
 	mode: core
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Gold token is an artifact")} with "Sacrifice this token: Add one mana of any color."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Gold token is an artifact")} with "Sacrifice this token: Add one mana of any color."
 #Ikoria: Lair of Behemoths
 keyword:
 	keyword: Mutate
@@ -1432,9 +1450,9 @@ keyword:
 #Magic 2021
 keyword:
 	keyword: Mill
-	match: <atom-param>mill</atom-param> <atom-param>one_word</atom-param> car<atom-param>*s</atom-param>
+	match: <atom-param>mill</atom-param> <atom-param>one_word</atom-param> card<atom-param>plural</atom-param>
 	mode: core
-	reminder: { if param1.value == "mills" then handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "They") + " put the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of their library into their graveyard." else handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "Put") + " the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of your library into your graveyard." }
+	reminder: { if is_plural(param1) then handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "They") + " put the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of their library into their graveyard." else handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "Put") + " the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of your library into your graveyard." }
 keyword:
 	keyword: phases out
 	match: phases out
@@ -1455,9 +1473,9 @@ keyword:
 #Kaldheim
 keyword:
 	keyword: Shard token
-	match: Shard toke<atom-param>*s</atom-param>
+	match: Shard token<atom-param>plural</atom-param>
 	mode: core
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re enchantments" else "It’s an enchantment", moved:"A Shard token is an enchantment")} with "2, Sacrifice this token: Scry ]1[, then draw a card."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re enchantments" else "It’s an enchantment", moved:"A Shard token is an enchantment")} with "2, Sacrifice this token: Scry ]1[, then draw a card."
 keyword:
 	keyword: Boast
 	match: Boast
@@ -1551,9 +1569,9 @@ keyword:
 	reminder: Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.
 keyword:
 	keyword: Blood token
-	match: Blood toke<atom-param>*s</atom-param>
+	match: Blood token<atom-param>plural</atom-param>
 	mode: expert
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Blood token is an artifact")} with "1, T, Discard a card, Sacrifice this token: Draw a card."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Blood token is an artifact")} with "1, T, Discard a card, Sacrifice this token: Draw a card."
 # Kamigawa Neon Dynasty
 keyword:
 	keyword: Reconfigure
@@ -1652,14 +1670,14 @@ keyword:
 	reminder: As this creature attacks, you may tap a nonattacking creature you control without summoning sickness. When you do, add its power to this creature's until end of turn.
 keyword:
 	keyword: Stun counters
-	match: stun counte<atom-param>*s</atom-param>
+	match: stun counter<atom-param>plural</atom-param>
 	mode: core
 	reminder: If a permanent with a stun counter would become untapped, remove one from it instead.
 keyword:
 	keyword: Powerstone token
-	match: Powerstone toke<atom-param>*s</atom-param>
+	match: Powerstone token<atom-param>plural</atom-param>
 	mode: expert
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Powerstone token is an artifact")} with "[T]: Add [C]. This mana can't be spent to cast a nonartifact spell."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Powerstone token is an artifact")} with "[T]: Add [C]. This mana can't be spent to cast a nonartifact spell."
 # Brother's War
 keyword:
 	keyword: Prototype
@@ -1779,9 +1797,9 @@ keyword:
 # Lost Caverns of Ixalan
 keyword:
 	keyword: Map token
-	match: Map toke<atom-param>*s</atom-param>
+	match: Map token<atom-param>plural</atom-param>
 	mode: expert
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Map token is an artifact")} with "1, T, Sacrifice this token: Target creature you control explores. Activate only as a sorcery."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Map token is an artifact")} with "1, T, Sacrifice this token: Target creature you control explores. Activate only as a sorcery."
 keyword:
 	keyword: Craft
 	match: Craft with <atom-param>name</atom-param> <atom-param>cost</atom-param>
@@ -1842,9 +1860,9 @@ keyword:
 # Fallout
 keyword:
 	keyword: Junk token
-	match: Junk toke<atom-param>*s</atom-param>
+	match: Junk token<atom-param>plural</atom-param>
 	mode: expert
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Junk token is an artifact")} with "T, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Junk token is an artifact")} with "T, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery."
 # Assassin's Creed
 keyword:
 	keyword: Freerunning
@@ -1874,7 +1892,7 @@ keyword:
 	reminder: You may {for_mana_costs(add:"pay ", param1)} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.
 keyword:
 	keyword: becomes plotted
-	match: becom<atom-param>*s</atom-param> plotted
+	match: become<atom-param>plural</atom-param> plotted
 	mode: expert
 	reminder: You may cast it as a sorcery on a later turn without paying its mana cost.
 keyword:
@@ -2042,9 +2060,9 @@ keyword:
 	reminder: You may cast this card from your hand for its warp cost. Exile this creature at the beginning of the next end step, then you may cast it from exile on a later turn.
 keyword:
 	keyword: Lander token
-	match: Lander toke<atom-param>*s</atom-param>
+	match: Lander token<atom-param>plural</atom-param>
 	mode: expert
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Lander token is an artifact")} with "[2], [T], Sacrificie this token: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Lander token is an artifact")} with "[2], [T], Sacrificie this token: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle."
 keyword:
 	keyword: Void
 	match: Void
@@ -2112,9 +2130,9 @@ keyword:
 	reminder: You may cast this spell for {param1} if you also return an unblocked attacker you control to hand during the declare blockers step.face_if_iscreature_then_ It enters tapped and attacking._else__end
 keyword:
 	keyword: Mutagen tokens
-	match: Mutagen toke<atom-param>*s</atom-param>
+	match: Mutagen token<atom-param>plural</atom-param>
 	mode: expert
-	reminder: {handle_merged_rt(if param1.value == "ns" then "They’re artifacts" else "It’s an artifact", moved:"A Mutagen token is an artifact")} with "[1], [T], Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery."
+	reminder: {handle_merged_rt(if is_plural(param1) then "They’re artifacts" else "It’s an artifact", moved:"A Mutagen token is an artifact")} with "[1], [T], Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery."
 #Secrets of Strixhaven
 keyword:
 	keyword: Paradigm

--- a/data/magic.mse-game/keywords_en
+++ b/data/magic.mse-game/keywords_en
@@ -1450,7 +1450,7 @@ keyword:
 #Magic 2021
 keyword:
 	keyword: Mill
-	match: <atom-param>mill</atom-param> <atom-param>one_word</atom-param> card<atom-param>plural</atom-param>
+	match: mill<atom-param>plural</atom-param> <atom-param>one_word</atom-param> card<atom-param>plural</atom-param>
 	mode: core
 	reminder: { if is_plural(param1) then handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "They") + " put the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of their library into their graveyard." else handle_action_rt(to:if param2 == "a" then "mill a card" else "mill {param2} cards", "Put") + " the top " + (if param2.value == "a" then "card " else param2 + " cards ") + "of your library into your graveyard." }
 keyword:

--- a/data/magic.mse-game/script
+++ b/data/magic.mse-game/script
@@ -1291,6 +1291,10 @@ handle_action_rt := {
 handle_action_rt_single := {
 	"<use-if-bumped>" + prefix + " " + to_lower(input) + "</use-if-bumped><otherwise>" + input + "</otherwise>"
 }
+
+clear_optional_placeholder := remove_tags + trim + replace@(match:"hidden", replace:"")
+is_plural := { clear_optional_placeholder(input) != "" }
+
 ############################################################## Complex reminder texts
 self_pro_check := match@(match:"You ha(ve|s) <kw-A><nospellcheck>protection")
 protection_code := {
@@ -1714,6 +1718,7 @@ text_filter :=
 		},
 		combine: {
 			keyword := "<nospellcheck><key>{keyword}</key></nospellcheck>"
+			keyword := replace(keyword, match:"<param[^>]+><atom-kwpph>hidden</atom-kwpph></param[^>]+>", replace:"")
 			reminder := process_english_hints(reminder)
 			if mode == "pseudo" then "<i-auto>{keyword}</i-auto>"
 			else keyword + if expand then "<atom-reminder-{mode}> ({reminder})</atom-reminder-{mode}>" else ""


### PR DESCRIPTION
While mse theoretically had support for optional keyword parameters, the placeholder text would still be rendered, eg "token\<s>", so instead we used the inelegant match "toke<*s>". This PR instead adds a step to text_filter to remove placeholders with a standard overwritten name, drafted as `<atom-kwpph>hidden</atom-kwpph>`

This does mostly function, "Type token\<plural>" and "Connive\<plural>\<optional_number>" both work correctly. But there are two weird interactions:
* If there is any plaintext—including just a space—after the optional param, it becomes mandatory. "a\<plural>b" matches "asb" but not "ab". This prevents updating into "become\<plural> plotted".
* If there are any parameters separated from the optional by plaintext, it becomes mandatory. This prevents updating into "mill\<plural> \<one_word> card\<plural>"

this is not returning `keyword` in expand_keywords(), so i think it's a hiccup in the matching, rather than some quirk in expand_keywords that returns no reminder text, and the script step that removes the empty placeholder def isn't involved. The only time `optional` is actually [referenced](https://github.com/G-e-n-e-v-e-n-s-i-S/MagicSetEditor2/blob/2f77e8c4c1b77b898752a1bc1e76dfd1d8993100/src/data/keyword.cpp#L189) is adding a `?` to that part of the regex, so I wouldn't think it's some bug with optional placeholders. My instinct is that it's something happening in the filtering happening at [possible_matches](https://github.com/G-e-n-e-v-e-n-s-i-S/MagicSetEditor2/blob/2f77e8c4c1b77b898752a1bc1e76dfd1d8993100/src/data/keyword.cpp#L388), but i can't follow it well enough to tell where

this is probably still an acceptable update with those examples left on the old method, but wanna make sure @G-e-n-e-v-e-n-s-i-S gets a chance to check the quirks before doing that.